### PR TITLE
feat: queue runner

### DIFF
--- a/encord_agents/tasks/__init__.py
+++ b/encord_agents/tasks/__init__.py
@@ -1,5 +1,5 @@
 from encord_agents.core.dependencies import Depends
 
-from .runner import Runner
+from .runner import QueueRunner, Runner
 
-__all__ = ["Runner", "Depends"]
+__all__ = ["Runner", "QueueRunner", "Depends"]

--- a/encord_agents/tasks/models.py
+++ b/encord_agents/tasks/models.py
@@ -1,6 +1,6 @@
 from uuid import UUID
-from encord.workflow.stages.agent import AgentTask
 
+from encord.workflow.stages.agent import AgentTask
 from pydantic import BaseModel, Field
 
 
@@ -13,7 +13,13 @@ class AgentTaskConfig(BaseModel):
 
 class TaskCompletionResult(BaseModel):
     task_uuid: UUID = Field(description="UUID of the task in the Encord Queueing system")
-    stage_uuid: UUID | None = Field(description="UUID of the workflow stage at which the task was executed. If None, the stage could not be identified from the `task_uuid`.", default=None)
+    stage_uuid: UUID | None = Field(
+        description="UUID of the workflow stage at which the task was executed. If None, the stage could not be identified from the `task_uuid`.",
+        default=None,
+    )
     success: bool = Field(description="Agent executed without errors")
-    pathway: str | UUID | None = Field(description="The pathway that the task was passed along to. If None, either the agent succeded but didn't return a pathway or the agent failed so the task didn't proceed.", default=None)
+    pathway: str | UUID | None = Field(
+        description="The pathway that the task was passed along to. If None, either the agent succeded but didn't return a pathway or the agent failed so the task didn't proceed.",
+        default=None,
+    )
     error: str | None = Field(description="Stack trace or error message if an error occured", default=None)

--- a/encord_agents/tasks/models.py
+++ b/encord_agents/tasks/models.py
@@ -23,6 +23,8 @@ class TaskCompletionResult(BaseModel):
         default=None,
     )
     success: bool = Field(description="Agent executed without errors")
+    # TODO: When we can read pathway definitions via the `encord` SDK, pathway can be typed None | UUID only.
+    # Currently, pathway can also be the name of the pathway.
     pathway: str | UUID | None = Field(
         description="The pathway that the task was passed along to. If None, either the agent succeded but didn't return a pathway or the agent failed so the task didn't proceed.",
         default=None,

--- a/encord_agents/tasks/models.py
+++ b/encord_agents/tasks/models.py
@@ -5,14 +5,15 @@ from pydantic import BaseModel, Field
 
 
 class AgentTaskConfig(BaseModel):
-    uuid: UUID = Field(description="The task uuid")
+    task_uuid: UUID = Field(description="The task uuid")
     data_hash: UUID = Field(description="The data hash of the underlying asset")
     data_title: str = Field(description="The data title used in the Encord system")
     label_branch_name: str = Field(description="The branch name of the associated labels")
 
 
 class TaskCompletionResult(BaseModel):
-    uuid: UUID = Field(description="UUID of the task in the Encord Queueing system")
+    task_uuid: UUID = Field(description="UUID of the task in the Encord Queueing system")
+    stage_uuid: UUID | None = Field(description="UUID of the workflow stage at which the task was executed. If None, the stage could not be identified from the `task_uuid`.", default=None)
     success: bool = Field(description="Agent executed without errors")
-    pathway: str | UUID | None = Field(description="The pathway that the task was passed along to", default=None)
+    pathway: str | UUID | None = Field(description="The pathway that the task was passed along to. If None, either the agent succeded but didn't return a pathway or the agent failed so the task didn't proceed.", default=None)
     error: str | None = Field(description="Stack trace or error message if an error occured", default=None)

--- a/encord_agents/tasks/models.py
+++ b/encord_agents/tasks/models.py
@@ -12,6 +12,11 @@ class AgentTaskConfig(BaseModel):
 
 
 class TaskCompletionResult(BaseModel):
+    """
+    Data model to hold information about the completion result of
+    `encord_agents.tasks.QueueRunner` agents.
+    """
+
     task_uuid: UUID = Field(description="UUID of the task in the Encord Queueing system")
     stage_uuid: UUID | None = Field(
         description="UUID of the workflow stage at which the task was executed. If None, the stage could not be identified from the `task_uuid`.",

--- a/encord_agents/tasks/models.py
+++ b/encord_agents/tasks/models.py
@@ -1,0 +1,16 @@
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class AgentTaskConfig(BaseModel):
+    uuid: UUID = Field(description="The task uuid")
+    data_hash: UUID = Field(description="The data hash of the underlying asset")
+    data_title: str = Field(description="The data title used in the Encord system")
+    label_branch_name: str = Field(description="The branch name of the associated labels")
+
+
+class TaskCompletionResult(BaseModel):
+    success: bool = Field(description="Agent executed without errors")
+    next_stage: str | UUID | None = Field(description="The pathway that the task was passed along to", default=None)
+    error: str | None = Field(description="Stack trace or error message if an error occured", default=None)

--- a/encord_agents/tasks/models.py
+++ b/encord_agents/tasks/models.py
@@ -1,4 +1,5 @@
 from uuid import UUID
+from encord.workflow.stages.agent import AgentTask
 
 from pydantic import BaseModel, Field
 
@@ -11,6 +12,7 @@ class AgentTaskConfig(BaseModel):
 
 
 class TaskCompletionResult(BaseModel):
+    uuid: UUID = Field(description="UUID of the task in the Encord Queueing system")
     success: bool = Field(description="Agent executed without errors")
-    next_stage: str | UUID | None = Field(description="The pathway that the task was passed along to", default=None)
+    pathway: str | UUID | None = Field(description="The pathway that the task was passed along to", default=None)
     error: str | None = Field(description="Stack trace or error message if an error occured", default=None)

--- a/encord_agents/tasks/models.py
+++ b/encord_agents/tasks/models.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 
 
 class AgentTaskConfig(BaseModel):
-    task_uuid: UUID = Field(description="The task uuid")
+    task_uuid: UUID = Field(description="The task uuid", validation_alias="uuid")
     data_hash: UUID = Field(description="The data hash of the underlying asset")
     data_title: str = Field(description="The data title used in the Encord system")
     label_branch_name: str = Field(description="The branch name of the associated labels")

--- a/encord_agents/tasks/runner.py
+++ b/encord_agents/tasks/runner.py
@@ -602,7 +602,7 @@ class QueueRunner(RunnerBase):
     def __call__(self, *args: Any, **kwds: Any) -> Any:
         raise NotImplementedError(
             "Calling the QueueRunner is not intended. "
-            "Prefer using wrapped functions with, e.g., modal or Celeray. "
+            "Prefer using wrapped functions with, e.g., modal or Celery. "
             "For more documentation, please see the `QueueRunner.stage` documetation below."
         )
 
@@ -642,8 +642,6 @@ class QueueRunner(RunnerBase):
 
         As the pseudo code indicates, `wrapped_function` understands how to take that string from
         the queue and resolve all your defined dependencies before calling `your_function`.
-
-        For a complete example,
         """
         stage_uuid, printable_name = self.validate_stage(stage)
 

--- a/encord_agents/tasks/runner.py
+++ b/encord_agents/tasks/runner.py
@@ -79,7 +79,6 @@ class RunnerBase:
             len([s for s in project.workflow.stages if s.stage_type == WorkflowStageType.AGENT]) > 0
         ), f"Provided project does not have any agent stages in it's workflow. {PROJECT_MUSTS}"
 
-
     def __init__(self, project_hash: str | UUID | None = None):
         """
         Initialize the runner with an optional project hash.
@@ -150,6 +149,7 @@ class RunnerBase:
         )
         self.agents.append(runner_agent)
         return runner_agent
+
 
 class Runner(RunnerBase):
     """
@@ -662,10 +662,14 @@ class QueueRunner(RunnerBase):
                             task.proceed(pathway_uuid=str(next_stage))
                         except ValueError:
                             task.proceed(pathway_name=str(next_stage))
-                    return TaskCompletionResult(task_uuid=task.uuid, stage_uuid=stage.uuid, success=True, pathway=next_stage).model_dump_json()
+                    return TaskCompletionResult(
+                        task_uuid=task.uuid, stage_uuid=stage.uuid, success=True, pathway=next_stage
+                    ).model_dump_json()
                 except Exception:
                     # TODO logging?
-                    return TaskCompletionResult(task_uuid=task.uuid, stage_uuid=stage.uuid, success=False, error=traceback.format_exc()).model_dump_json()
+                    return TaskCompletionResult(
+                        task_uuid=task.uuid, stage_uuid=stage.uuid, success=False, error=traceback.format_exc()
+                    ).model_dump_json()
 
             return wrapper
 
@@ -675,7 +679,7 @@ class QueueRunner(RunnerBase):
         """
         Get the agent stages for which there exist an agent implementation.
 
-        This function is intended to make it easy to put agent tasks into 
+        This function is intended to make it easy to put agent tasks into
         external queueing systems like Celeray or Modal.
 
         *Example:*

--- a/encord_agents/tasks/runner.py
+++ b/encord_agents/tasks/runner.py
@@ -622,6 +622,7 @@ class QueueRunner(RunnerBase):
                     stage = self.project.workflow.get_stage(uuid=runner_agent.identity, type_=AgentStage)
                 except ValueError as e:
                     return TaskCompletionResult(
+                        uuid=conf.uuid,
                         success=False,
                         error=str(e),
                     ).model_dump_json()
@@ -630,6 +631,7 @@ class QueueRunner(RunnerBase):
                 if task is None:
                     # TODO logging?
                     return TaskCompletionResult(
+                        uuid=conf.uuid,
                         success=False,
                         error="Failed to obtain task from Encord",
                     ).model_dump_json()
@@ -661,10 +663,10 @@ class QueueRunner(RunnerBase):
                             task.proceed(pathway_uuid=str(next_stage))
                         except ValueError:
                             task.proceed(pathway_name=str(next_stage))
-                    return TaskCompletionResult(success=True, pathway=next_stage).model_dump_json()
+                    return TaskCompletionResult(uuid=task.uuid, success=True, pathway=next_stage).model_dump_json()
                 except Exception:
                     # TODO logging?
-                    return TaskCompletionResult(success=False, error=traceback.format_exc()).model_dump_json()
+                    return TaskCompletionResult(uuid=task.uuid, success=False, error=traceback.format_exc()).model_dump_json()
 
             return wrapper
 


### PR DESCRIPTION
For organisations with bigger workloads who want to run task agents, it's might not be feasible to use the `encord_agents.tasks.Runner` method as it's sequential and doesn't really permit distributed work.

This PR solves that problem.

With the `QueueRunner`, you can reuse the same implementation of your agent but in a new context.

If you had this before

```python
runner = Runner(project_hash="...")

@runner.stage("...")
def my_func(...) -> str:
    ...

runner()
```

you can now change it to
```python
runner = QueueRunner(project_hash="...")

@runner.stage("...")  # <- stays the same
def my_func(...) -> str:
    ...

# Submit tasks
task_queue = ... # e.g., Celery
for stage in runner.get_agent_stages():
    for task in stage.get_tasks():
        task_queue.put(task.model_dump_json())

# Execute task
task = task_queue.get_next()
while task:
    result = my_func(task)
    task = task_queue.get_next()
```

This should be much more suitable for distributed work.

## What will come next
- Docs on how to distribute it with [Modal](modal.com) and Celery[reddis]
- Setting up integration tests as we get more and more moving parts