### PR TITLE
misc: Introduce user agent suffix for encord-agents library

### DIFF
--- a/encord_agents/_version.py
+++ b/encord_agents/_version.py
@@ -1,0 +1,3 @@
+import importlib.metadata as importlib_metadata
+
+__version__ = importlib_metadata.version("encord")

--- a/encord_agents/_version.py
+++ b/encord_agents/_version.py
@@ -1,3 +1,0 @@
-import importlib.metadata as importlib_metadata
-
-__version__ = importlib_metadata.version("encord")

--- a/encord_agents/core/utils.py
+++ b/encord_agents/core/utils.py
@@ -28,9 +28,10 @@ def get_user_client() -> EncordUserClient:
 
     """
     settings = Settings()
-    kwargs: dict[str, Any] = (
-        {"domain": settings.domain, "user_agent_suffix": f"encord-agents/{__version__}"} if settings.domain else {}
-    )
+    kwargs: dict[str, Any] = {"user_agent_suffix": f"encord-agents/{__version__}"}
+
+    if settings.domain:
+        kwargs["domain"] = settings.domain
     return EncordUserClient.create_with_ssh_private_key(ssh_private_key=settings.ssh_key, **kwargs)
 
 

--- a/encord_agents/core/utils.py
+++ b/encord_agents/core/utils.py
@@ -13,6 +13,7 @@ from encord.user_client import EncordUserClient
 
 from encord_agents.core.data_model import FrameData, LabelRowInitialiseLabelsArgs, LabelRowMetadataIncludeArgs
 from encord_agents.core.settings import Settings
+from encord_agents._version import __version__
 
 from .video import get_frame
 
@@ -27,7 +28,7 @@ def get_user_client() -> EncordUserClient:
 
     """
     settings = Settings()
-    kwargs: dict[str, Any] = {"domain": settings.domain} if settings.domain else {}
+    kwargs: dict[str, Any] = {"domain": settings.domain, "user_agent_suffix": f"encord-agents/{__version__}"} if settings.domain else {}
     return EncordUserClient.create_with_ssh_private_key(ssh_private_key=settings.ssh_key, **kwargs)
 
 

--- a/encord_agents/core/utils.py
+++ b/encord_agents/core/utils.py
@@ -11,9 +11,9 @@ from encord.constants.enums import DataType
 from encord.objects.ontology_labels_impl import LabelRowV2
 from encord.user_client import EncordUserClient
 
+from encord_agents import __version__
 from encord_agents.core.data_model import FrameData, LabelRowInitialiseLabelsArgs, LabelRowMetadataIncludeArgs
 from encord_agents.core.settings import Settings
-from encord_agents._version import __version__
 
 from .video import get_frame
 
@@ -28,7 +28,9 @@ def get_user_client() -> EncordUserClient:
 
     """
     settings = Settings()
-    kwargs: dict[str, Any] = {"domain": settings.domain, "user_agent_suffix": f"encord-agents/{__version__}"} if settings.domain else {}
+    kwargs: dict[str, Any] = (
+        {"domain": settings.domain, "user_agent_suffix": f"encord-agents/{__version__}"} if settings.domain else {}
+    )
     return EncordUserClient.create_with_ssh_private_key(ssh_private_key=settings.ssh_key, **kwargs)
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,25 @@
+import os
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+import encord_agents
+from encord_agents.core.utils import get_user_client
+
+PRIVATE_KEY = Ed25519PrivateKey.generate()
+
+
+PRIVATE_KEY_PEM = PRIVATE_KEY.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.OpenSSH,
+    encryption_algorithm=serialization.NoEncryption(),
+).decode("utf-8")
+
+
+@pytest.mark.skipif(encord_agents.__version__ <= "v0.1.5", reason="Underlying Encord dependency not yet bumped")
+def test_user_agent_defined_appropriately() -> None:
+    os.environ["ENCORD_SSH_KEY"] = PRIVATE_KEY_PEM
+    user_client = get_user_client()
+
+    assert "encord-agent" in user_client._api_client._config._user_agent()


### PR DESCRIPTION
Also introduce a __version__ attribute part of the library.

Follows this: https://peps.python.org/pep-0396/ which isn't necessarily an admitted 