### PR TITLE
feat: Allow overrriding stages.

### DIFF
--- a/encord_agents/tasks/runner.py
+++ b/encord_agents/tasks/runner.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 import traceback
@@ -29,6 +30,8 @@ from encord_agents.exceptions import PrintableError
 from .models import AgentTaskConfig, TaskCompletionResult
 
 TaskAgentReturn = str | UUID | None
+
+logger = logging.getLogger(__name__)
 
 
 class RunnerAgent:
@@ -132,6 +135,8 @@ class RunnerBase:
                     f"Stage name [blue]`{printable_name}`[/blue] has already been assigned a function. You can only assign one callable to each agent stage."
                 )
             self.agents = [agent for agent in self.agents if agent.identity != stage]
+            if len(self.agents) >= 1:
+                logger.warning("Overriding the Stage will change the order of execution for the stages")
         return stage, printable_name
 
     def _add_stage_agent(

--- a/encord_agents/tasks/runner.py
+++ b/encord_agents/tasks/runner.py
@@ -102,7 +102,7 @@ class RunnerBase:
             self.valid_stages = [s for s in self.project.workflow.stages if s.stage_type == WorkflowStageType.AGENT]
         self.agents: list[RunnerAgent] = []
 
-    def validate_stage(self, stage: str | UUID) -> tuple[UUID | str, str]:
+    def validate_stage(self, stage: str | UUID, *, overwrite: bool = False) -> tuple[UUID | str, str]:
         """
         Returns stage uuid and printable name.
         """
@@ -127,9 +127,11 @@ class RunnerBase:
             stage = selected_stage.uuid
 
         if stage in [a.identity for a in self.agents]:
-            raise PrintableError(
-                f"Stage name [blue]`{printable_name}`[/blue] has already been assigned a function. You can only assign one callable to each agent stage."
-            )
+            if not overwrite:
+                raise PrintableError(
+                    f"Stage name [blue]`{printable_name}`[/blue] has already been assigned a function. You can only assign one callable to each agent stage."
+                )
+            self.agents = [agent for agent in self.agents if agent.identity != stage]
         return stage, printable_name
 
     def _add_stage_agent(
@@ -205,6 +207,7 @@ class Runner(RunnerBase):
         *,
         label_row_metadata_include_args: LabelRowMetadataIncludeArgs | None = None,
         label_row_initialise_labels_args: LabelRowInitialiseLabelsArgs | None = None,
+        overwrite: bool = False,
     ) -> Callable[[DecoratedCallable], DecoratedCallable]:
         r"""
         Decorator to associate a function with an agent stage.
@@ -279,15 +282,21 @@ class Runner(RunnerBase):
                 `project.list_label_rows_v2(...)`
             label_row_initialise_labels_args: Arguments to be passed to
                 `label_row.initialise_labels(...)`
+            overwrite: Overwrite the method associated to this stage if it already exists
+                will throw an error otherwise
 
         Returns:
             The decorated function.
         """
-        stage_uuid, printable_name = self.validate_stage(stage)
+        stage_uuid, printable_name = self.validate_stage(stage, overwrite=overwrite)
 
         def decorator(func: DecoratedCallable) -> DecoratedCallable:
             self._add_stage_agent(
-                stage_uuid, func, printable_name, label_row_metadata_include_args, label_row_initialise_labels_args
+                stage_uuid,
+                func,
+                printable_name,
+                label_row_metadata_include_args,
+                label_row_initialise_labels_args,
             )
             return func
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,26 @@
+import pytest
+
+from encord_agents.exceptions import PrintableError
+from encord_agents.tasks.runner import Runner
+
+
+def test_overrride_runner() -> None:
+    runner = Runner()
+
+    @runner.stage(stage="Yep")
+    def method_1() -> str:
+        return "1"
+
+    with pytest.raises(PrintableError):
+
+        @runner.stage(stage="Yep")
+        def method_2() -> str:
+            return "2"
+
+    @runner.stage(stage="Yep", overwrite=True)
+    def method_3() -> str:
+        return "3"
+
+    assert len(runner.agents) == 1
+    agent_YEP = runner.agents[0]
+    assert agent_YEP.callable() == "3"


### PR DESCRIPTION
When developing agents in an REPL environment, one often wants to modify the agent and then re-run the code. Currently we have to re-define the Agent on a top level. This change would allow that
NEEDS TEST most likely