### PR TITLE
misc: Allow only attempting finite number of tasks at once

### DIFF
--- a/encord_agents/tasks/runner.py
+++ b/encord_agents/tasks/runner.py
@@ -18,7 +18,7 @@ from encord.workflow.stages.agent import AgentStage, AgentTask
 from encord.workflow.workflow import WorkflowStage
 from rich.panel import Panel
 from tqdm.auto import tqdm
-from typer import Abort, Option
+from typer import Abort, BadParameter, Option
 from typing_extensions import Annotated
 
 from encord_agents.core.data_model import LabelRowInitialiseLabelsArgs, LabelRowMetadataIncludeArgs
@@ -81,6 +81,13 @@ class RunnerBase:
         assert (
             len([s for s in project.workflow.stages if s.stage_type == WorkflowStageType.AGENT]) > 0
         ), f"Provided project does not have any agent stages in it's workflow. {PROJECT_MUSTS}"
+
+    @staticmethod
+    def validate_max_tasks_per_stage(max_tasks_per_stage: int | None) -> int | None:
+        if max_tasks_per_stage is not None:
+            if max_tasks_per_stage < 1:
+                raise PrintableError("We require that `max_tasks_per_stage` >= 1")
+        return max_tasks_per_stage
 
     def __init__(self, project_hash: str | UUID | None = None):
         """
@@ -364,7 +371,9 @@ class Runner(RunnerBase):
         ] = None,
         max_tasks_per_stage: Annotated[
             Optional[int],
-            Option(help="Max number of tasks to try to process per stage on a given run. If `None`, will attempt all"),
+            Option(
+                help="Max number of tasks to try to process per stage on a given run. If `None`, will attempt all",
+            ),
         ] = None,
     ) -> None:
         """
@@ -384,6 +393,9 @@ class Runner(RunnerBase):
         Returns:
             None
         """
+        # Verify args that don't depend on external service first
+        max_tasks_per_stage = self.validate_max_tasks_per_stage(max_tasks_per_stage)
+
         # Verify project
         if project_hash is not None:
             project_hash = self.verify_project_hash(project_hash)
@@ -406,11 +418,6 @@ class Runner(RunnerBase):
             )
 
         self.validate_project(project)
-
-        # Verify args
-        if max_tasks_per_stage is not None:
-            if max_tasks_per_stage < 1:
-                raise PrintableError("We require that `max_tasks_per_stage` >= 1")
         # Verify stages
         valid_stages = [s for s in project.workflow.stages if s.stage_type == WorkflowStageType.AGENT]
         agent_stages: dict[str | UUID, WorkflowStage] = {
@@ -481,9 +488,7 @@ def {fn_name}(...):
                     batch: list[AgentTask] = []
                     batch_lrs: list[LabelRowV2 | None] = []
 
-                    tasks = list(stage.get_tasks())
-                    if max_tasks_per_stage:
-                        tasks = tasks[:max_tasks_per_stage]
+                    tasks = list(stage.get_tasks())[:max_tasks_per_stage]
                     pbar = tqdm(desc=f"Executing tasks for stage: {stage.title}", total=len(tasks))
                     for task in tasks:
                         if not isinstance(task, AgentTask):

--- a/encord_agents/tasks/runner.py
+++ b/encord_agents/tasks/runner.py
@@ -407,6 +407,10 @@ class Runner(RunnerBase):
 
         self.validate_project(project)
 
+        # Verify args
+        if max_tasks_per_stage is not None:
+            if max_tasks_per_stage < 1:
+                raise PrintableError("We require that `max_tasks_per_stage` >= 1")
         # Verify stages
         valid_stages = [s for s in project.workflow.stages if s.stage_type == WorkflowStageType.AGENT]
         agent_stages: dict[str | UUID, WorkflowStage] = {

--- a/encord_agents/tasks/runner.py
+++ b/encord_agents/tasks/runner.py
@@ -362,6 +362,10 @@ class Runner(RunnerBase):
         project_hash: Annotated[
             Optional[str], Option(help="The project hash if not defined at runner instantiation.")
         ] = None,
+        max_tasks_per_stage: Annotated[
+            Optional[int],
+            Option(help="Max number of tasks to try to process per stage on a given run. If `None`, will attempt all"),
+        ] = None,
     ) -> None:
         """
         Run your task agent `runner(...)`.
@@ -474,6 +478,8 @@ def {fn_name}(...):
                     batch_lrs: list[LabelRowV2 | None] = []
 
                     tasks = list(stage.get_tasks())
+                    if max_tasks_per_stage:
+                        tasks = tasks[:max_tasks_per_stage]
                     pbar = tqdm(desc=f"Executing tasks for stage: {stage.title}", total=len(tasks))
                     for task in tasks:
                         if not isinstance(task, AgentTask):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,4 +1,5 @@
 import pytest
+from typer import BadParameter
 
 from encord_agents.exceptions import PrintableError
 from encord_agents.tasks.runner import Runner
@@ -24,3 +25,11 @@ def test_overrride_runner() -> None:
     assert len(runner.agents) == 1
     agent_YEP = runner.agents[0]
     assert agent_YEP.callable() == "3"
+
+
+def test_max_tasks_per_stage_validation() -> None:
+    runner = Runner()
+
+    with pytest.raises(PrintableError):
+        runner(max_tasks_per_stage=-1)
+    # As is, can't test actually making max_tasks without major re-factor / mocking


### PR DESCRIPTION
Another thing that could be worthwhile for the task runner:
Optionally taking N_tasks per stage. Where basically we do atmost N_tasks per stage, this allows people to try out the agent on a subset if they have a complicated flow.:
i.e: I want to check agent_1 -> agent_2 -> agent_3 works and don't want to run all of agent_1.

Having tested this, this is super useful for involved workflows where we want to check that a singular item can move across the all stages easily