### PR TITLE
misc: Expand docstring to warn about format dangers

### DIFF
--- a/encord_agents/tasks/dependencies.py
+++ b/encord_agents/tasks/dependencies.py
@@ -84,6 +84,8 @@ def dep_single_frame(lr: LabelRowV2) -> NDArray[np.uint8]:
 def dep_video_iterator(lr: LabelRowV2) -> Generator[Iterator[Frame], None, None]:
     """
     Dependency to inject a video frame iterator for doing things over many frames.
+    This will use OpenCV and the local backend on your machine.
+    Decoding support may vary dependant on the video format, codec and your local configuration
 
     **Intended use**
 


### PR DESCRIPTION
I had a video which was not marked as having errors on the Encord platform throw an error here which hurts a bit.
Warn users about this. Ideally if we could have sufficient dependencies to cover at least .avi:
https://web.archive.org/web/20130524095153/http://opencv.willowgarage.com/wiki/VideoCodecs
which seems to be recommended on all platforms, then we could indicate as such.
We don't want to be offering too much support here cause it's very dependant on users ffmpeg and other machine libs that we can't particularly control nor want too