### PR TITLE
feat: Bump encord and utilise new Pathway attribute to validate agent response earlier

### DIFF
--- a/encord_agents/tasks/models.py
+++ b/encord_agents/tasks/models.py
@@ -1,6 +1,5 @@
 from uuid import UUID
 
-from encord.workflow.stages.agent import AgentTask
 from pydantic import BaseModel, Field
 
 
@@ -23,10 +22,8 @@ class TaskCompletionResult(BaseModel):
         default=None,
     )
     success: bool = Field(description="Agent executed without errors")
-    # TODO: When we can read pathway definitions via the `encord` SDK, pathway can be typed None | UUID only.
-    # Currently, pathway can also be the name of the pathway.
-    pathway: str | UUID | None = Field(
-        description="The pathway that the task was passed along to. If None, either the agent succeeded but didn't return a pathway or the agent failed so the task didn't proceed.",
+    pathway: UUID | None = Field(
+        description="The UUID of the pathway that the task was passed along to. If None, either the agent succeeded but didn't return a pathway or the agent failed so the task didn't proceed.",
         default=None,
     )
     error: str | None = Field(description="Stack trace or error message if an error occurred", default=None)

--- a/encord_agents/tasks/runner.py
+++ b/encord_agents/tasks/runner.py
@@ -378,25 +378,24 @@ class Runner(RunnerBase):
                             if next_stage is None:
                                 pass
                             elif isinstance(next_stage, UUID) or try_coerce_UUID(next_stage):
-                                try:
-                                    task.proceed(pathway_uuid=str(next_stage), bundle=bundle)
-                                except InvalidArgumentsError:
+                                if next_stage not in [str(pathway.uuid) for pathway in stage.pathways]:
                                     raise PrintableError(
                                         f"No pathway with UUID: {next_stage} found. Accepted pathway UUIDs are: {[pathway.uuid for pathway in stage.pathways]}"
                                     )
+                                task.proceed(pathway_uuid=str(next_stage), bundle=bundle)
                             else:
-                                try:
-                                    task.proceed(pathway_name=next_stage, bundle=bundle)
-                                except InvalidArgumentsError:
+                                if next_stage not in [str(pathway.name) for pathway in stage.pathways]:
                                     raise PrintableError(
                                         f"No pathway with name: {next_stage} found. Accepted pathway UUIDs are: {[pathway.name for pathway in stage.pathways]}"
                                     )
-
+                                task.proceed(pathway_name=next_stage, bundle=bundle)
                             if pbar_update is not None:
                                 pbar_update(1.0)
                             break
 
                         except KeyboardInterrupt:
+                            raise
+                        except PrintableError:
                             raise
                         except Exception:
                             print(f"[attempt {attempt+1}/{num_retries+1}] Agent failed with error: ")

--- a/encord_agents/tasks/runner.py
+++ b/encord_agents/tasks/runner.py
@@ -832,13 +832,15 @@ class QueueRunner(RunnerBase):
                     else:
                         if next_stage not in [pathway.name for pathway in stage.pathways]:
                             raise PrintableError(
-                                f"Runner responded with pathway UUID: {next_stage}, only accept: {[pathway.uuid for pathway in stage.pathways]}"
+                                f"Runner responded with pathway name: {next_stage}, only accept: {[pathway.name for pathway in stage.pathways]}"
                             )
                         task.proceed(pathway_name=str(next_stage))
                         next_stage_uuid = name_lookup[str(next_stage)]
                     return TaskCompletionResult(
                         task_uuid=task.uuid, stage_uuid=stage.uuid, success=True, pathway=next_stage_uuid
                     ).model_dump_json()
+                except PrintableError:
+                    raise
                 except Exception:
                     # TODO logging?
                     return TaskCompletionResult(

--- a/encord_agents/tasks/runner.py
+++ b/encord_agents/tasks/runner.py
@@ -386,7 +386,7 @@ class Runner(RunnerBase):
                             else:
                                 if next_stage not in [str(pathway.name) for pathway in stage.pathways]:
                                     raise PrintableError(
-                                        f"No pathway with name: {next_stage} found. Accepted pathway UUIDs are: {[pathway.name for pathway in stage.pathways]}"
+                                        f"No pathway with name: {next_stage} found. Accepted pathway names are: {[pathway.name for pathway in stage.pathways]}"
                                     )
                                 task.proceed(pathway_name=str(next_stage), bundle=bundle)
                             if pbar_update is not None:
@@ -775,6 +775,7 @@ class QueueRunner(RunnerBase):
             try:
                 stage = self._project.workflow.get_stage(uuid=runner_agent.identity, type_=AgentStage)
             except ValueError as err:
+                # Local binding to help mypy
                 error = err
 
                 @wraps(func)

--- a/encord_agents/utils/generic_utils.py
+++ b/encord_agents/utils/generic_utils.py
@@ -1,12 +1,11 @@
 from uuid import UUID
 
 
-def try_coerce_UUID(candidate_uuid: str | UUID) -> bool:
-    """Try to coerce to UUID. Return true if possible otherwise false"""
+def try_coerce_UUID(candidate_uuid: str | UUID) -> UUID | None:
+    """Try to coerce to UUID. Return UUID if possible otherwise None"""
     if isinstance(candidate_uuid, UUID):
-        return True
+        return candidate_uuid
     try:
-        UUID(candidate_uuid)
-        return True
+        return UUID(candidate_uuid)
     except ValueError:
-        return False
+        return None

--- a/encord_agents/utils/generic_utils.py
+++ b/encord_agents/utils/generic_utils.py
@@ -1,0 +1,12 @@
+from uuid import UUID
+
+
+def try_coerce_UUID(candidate_uuid: str | UUID) -> bool:
+    """Try to coerce to UUID. Return true if possible otherwise false"""
+    if isinstance(candidate_uuid, UUID):
+        return True
+    try:
+        UUID(candidate_uuid)
+        return True
+    except ValueError:
+        return False

--- a/poetry.lock
+++ b/poetry.lock
@@ -677,13 +677,13 @@ files = [
 
 [[package]]
 name = "encord"
-version = "0.1.155"
+version = "0.1.158"
 description = "Encord Python SDK Client"
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "encord-0.1.155-py3-none-any.whl", hash = "sha256:07541f1200035b20fd187c650050fa303797bc70c2067f8db05b3b9a64fb56c7"},
-    {file = "encord-0.1.155.tar.gz", hash = "sha256:c388a238b32db8e2fac9c83537630c0e368d53eb9617bee9d09155f506621ba4"},
+    {file = "encord-0.1.158-py3-none-any.whl", hash = "sha256:b13e81040cade9af21af7fa0734ce87e809096a096a981f2cad81b601f7d4ae9"},
+    {file = "encord-0.1.158.tar.gz", hash = "sha256:3a06053e05561db1976c7bacc7774dc99129206213332ee5bbc5126f405ad7ef"},
 ]
 
 [package.dependencies]
@@ -695,7 +695,7 @@ requests = ">=2.25.0,<3.0.0"
 tqdm = ">=4.32.1,<5.0.0"
 
 [package.extras]
-coco = ["pycocotools (>=2.0.7,<3.0.0)", "shapely (>=2.0.4,<3.0.0)"]
+coco = ["numpy (>=1.24,<2.0)", "numpy (>=1.26,<2.0)", "opencv-python (>=4.11.0.86,<5.0.0.0)", "pycocotools (>=2.0.7,<3.0.0)", "shapely (>=2.0.4,<3.0.0)"]
 
 [[package]]
 name = "exceptiongroup"
@@ -3736,4 +3736,4 @@ test = ["websockets"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e84d2dd62c5402970eaf8cb95b9e1ce6d484340aee324240504a5aa9e0c27b24"
+content-hash = "c7af1cf72574d0962656bd60ab2f3c427f10fd48181b7171d733b8e89a705de5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ requests = "^2.32.3"
 typing-extensions = ">=4.8.0"
 
 # No-CLI dependencies
-encord = ">=0.1.155"
+encord = ">=0.1.158"
 numpy = ">=1.26.4"
 opencv-python = ">=4.1"
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -28,7 +28,7 @@ AGENT_TO_COMPLETE_WORKFLOW_HASH = "a59b3190-09e2-432c-a8bb-f2925872e298"
 AGENT_STAGE_NAME = "Agent 1"
 COMPLETE_STAGE_NAME = "Complete"
 AGENT_TO_COMPLETE_PATHWAY_HASH = "49a786f3-5edf-4b94-aff0-3da9042d3bf0"
-AGENT_TO_COMPLETE_PATHWAY_NAME = "Complete"
+AGENT_TO_COMPLETE_PATHWAY_NAME = "complete"
 
 EPHEMERAL_PROJECT_TITLE = "encord-agents test project"
 EPHEMERAL_PROJECT_DESCRIPTION = "encord-agents test project description"
@@ -106,7 +106,7 @@ def workflow_hash(
     │  start  ├───►│  Agent 1  ├─┬─►│  Complete  │
     └─────────┘    └───────────┘ │  └────────────┘
                                 │
-                            Name: "Complete"
+                            Name: "complete"
                             Uuid: "49a786f3-5edf-4b94-aff0-3da9042d3bf0"
     """
     return AGENT_TO_COMPLETE_WORKFLOW_HASH

--- a/tests/integration_tests/tasks/test_queue_runner.py
+++ b/tests/integration_tests/tasks/test_queue_runner.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+from uuid import UUID
 
 import pytest
 from encord.user_client import EncordUserClient
@@ -10,6 +11,7 @@ from encord_agents.tasks import QueueRunner
 from encord_agents.tasks.models import TaskCompletionResult
 from tests.fixtures import (
     AGENT_STAGE_NAME,
+    AGENT_TO_COMPLETE_PATHWAY_HASH,
     AGENT_TO_COMPLETE_PATHWAY_NAME,
     COMPLETE_STAGE_NAME,
 )
@@ -62,7 +64,7 @@ def test_queue_runner_e2e(ephemeral_project_hash: str, mock_agent: MagicMock) ->
         result = TaskCompletionResult.model_validate_json(result_json)
         assert result.success
         assert not result.error
-        assert result.pathway == AGENT_TO_COMPLETE_PATHWAY_NAME
+        assert result.pathway == UUID(AGENT_TO_COMPLETE_PATHWAY_HASH)
         assert result.stage_uuid == agent_stage.uuid
         assert result.task_uuid == agent_task.uuid
 

--- a/tests/integration_tests/tasks/test_queue_runner.py
+++ b/tests/integration_tests/tasks/test_queue_runner.py
@@ -135,7 +135,6 @@ def test_runner_throws_error_if_wrong_pathway(ephemeral_project_hash: str, pathw
         task_spec = queue.pop()
         with pytest.raises(PrintableError) as e:
             agent_function(task_spec)
-        # TODO: It's possible that we want to treat incorrect pathway names akin to putting None and just silently fail and record it in the TaskCompletionResult
         if pathway_name:
             assert AGENT_TO_COMPLETE_PATHWAY_NAME in str(e)
         else:

--- a/tests/integration_tests/tasks/test_sequential_runner.py
+++ b/tests/integration_tests/tasks/test_sequential_runner.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+from uuid import UUID, uuid4
 
 import pytest
 from encord.user_client import EncordUserClient
@@ -221,3 +222,20 @@ def test_project_validation_callback_throws(
 
     with pytest.raises(AssertionError):
         runner(project_hash=ephemeral_project_hash if not provide_project_hash_at_define_time else None)
+
+
+@pytest.mark.parametrize(
+    "pathway_name", [pytest.param(True, id="Pass an incorrect name"), pytest.param(False, id="Pass an incorrect UUID")]
+)
+def test_runner_throws_error_if_wrong_pathway(ephemeral_project_hash: str, pathway_name: bool) -> None:
+    runner = Runner(project_hash=ephemeral_project_hash)
+
+    wrong_pathway: str | UUID = "Not the name of the pathway" if pathway_name else uuid4()
+
+    @runner.stage(AGENT_STAGE_NAME)
+    def agent_function(task: AgentTask) -> str | UUID:
+        return wrong_pathway
+
+    # Run the runner
+    with pytest.raises(PrintableError):
+        runner()

--- a/tests/integration_tests/tasks/test_sequential_runner.py
+++ b/tests/integration_tests/tasks/test_sequential_runner.py
@@ -245,6 +245,6 @@ def test_runner_throws_error_if_wrong_pathway(ephemeral_project_hash: str, pathw
     with pytest.raises(PrintableError) as e:
         runner()
     if pathway_name:
-        assert AGENT_TO_COMPLETE_PATHWAY_NAME.lower() in str(e)
+        assert AGENT_TO_COMPLETE_PATHWAY_NAME in str(e)
     else:
         assert AGENT_TO_COMPLETE_PATHWAY_HASH in str(e)

--- a/tests/integration_tests/tasks/test_sequential_runner.py
+++ b/tests/integration_tests/tasks/test_sequential_runner.py
@@ -9,7 +9,12 @@ from encord.workflow.stages.final import FinalStage
 from encord_agents.core.utils import batch_iterator
 from encord_agents.exceptions import PrintableError
 from encord_agents.tasks import Runner
-from tests.fixtures import AGENT_STAGE_NAME, AGENT_TO_COMPLETE_PATHWAY_NAME, COMPLETE_STAGE_NAME
+from tests.fixtures import (
+    AGENT_STAGE_NAME,
+    AGENT_TO_COMPLETE_PATHWAY_HASH,
+    AGENT_TO_COMPLETE_PATHWAY_NAME,
+    COMPLETE_STAGE_NAME,
+)
 
 
 @pytest.fixture
@@ -237,5 +242,9 @@ def test_runner_throws_error_if_wrong_pathway(ephemeral_project_hash: str, pathw
         return wrong_pathway
 
     # Run the runner
-    with pytest.raises(PrintableError):
+    with pytest.raises(PrintableError) as e:
         runner()
+    if pathway_name:
+        assert AGENT_TO_COMPLETE_PATHWAY_NAME.lower() in str(e)
+    else:
+        assert AGENT_TO_COMPLETE_PATHWAY_HASH in str(e)


### PR DESCRIPTION
WE can check client side. One distinction as the BE is actually **case-insensitive** when going from a pathway name so we should consider replicating that here.