### PR TITLE
feat: Agent stage as dependency. Allows resolution of pathways at define time

### DIFF
--- a/encord_agents/core/dependencies/models.py
+++ b/encord_agents/core/dependencies/models.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from encord.objects.ontology_labels_impl import LabelRowV2
 from encord.project import Project
-from encord.workflow.stages.agent import AgentTask
+from encord.workflow.stages.agent import AgentStage, AgentTask
 
 from encord_agents.core.data_model import FrameData
 
@@ -41,6 +41,7 @@ class Context:
     label_row: LabelRowV2 | None
     task: AgentTask | None = None
     frame_data: FrameData | None = None
+    agent_stage: AgentStage | None = None
 
 
 @dataclass

--- a/encord_agents/core/dependencies/utils.py
+++ b/encord_agents/core/dependencies/utils.py
@@ -182,7 +182,7 @@ def get_field_values(
         elif param_field.type_annotation is AgentStage:
             if context.agent_stage is None:
                 raise ValueError(
-                    "It looks like you're trying to access an agent stage from an editor agent. That is not supported, as editor agents are not associated with tasks."
+                    "It looks like you're trying to access an agent stage from an editor agent. That is not supported, as editor agents are not associated with particular stages."
                 )
             values[param_field.name] = context.agent_stage
         else:

--- a/encord_agents/core/dependencies/utils.py
+++ b/encord_agents/core/dependencies/utils.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, ForwardRef, Optional, cast
 
 from encord.objects.ontology_labels_impl import LabelRowV2
 from encord.project import Project
-from encord.workflow.stages.agent import AgentTask
+from encord.workflow.stages.agent import AgentStage, AgentTask
 from pydantic._internal._typing_extra import eval_type_lenient as evaluate_forwardref
 from typing_extensions import Annotated, get_args, get_origin
 
@@ -154,8 +154,10 @@ def solve_generator(*, call: Callable[..., Any], stack: ExitStack, sub_values: d
     return stack.enter_context(cm)
 
 
-def get_field_values(deps: list[_Field], context: Context) -> dict[str, AgentTask | LabelRowV2 | Project | FrameData]:
-    values: dict[str, AgentTask | LabelRowV2 | Project | FrameData] = {}
+def get_field_values(
+    deps: list[_Field], context: Context
+) -> dict[str, AgentTask | AgentStage | LabelRowV2 | Project | FrameData]:
+    values: dict[str, AgentTask | AgentStage | LabelRowV2 | Project | FrameData] = {}
     for param_field in deps:
         if param_field.type_annotation is FrameData:
             if context.frame_data is None:
@@ -177,6 +179,12 @@ def get_field_values(deps: list[_Field], context: Context) -> dict[str, AgentTas
             values[param_field.name] = context.label_row
         elif param_field.type_annotation is Project:
             values[param_field.name] = context.project
+        elif param_field.type_annotation is AgentStage:
+            if context.agent_stage is None:
+                raise ValueError(
+                    "It looks like you're trying to access an agent stage from an editor agent. That is not supported, as editor agents are not associated with tasks."
+                )
+            values[param_field.name] = context.agent_stage
         else:
             raise ValueError(
                 f"Agent function is specifying a field `{param_field.name}` with type `{param_field.type_annotation}` "

--- a/encord_agents/tasks/runner.py
+++ b/encord_agents/tasks/runner.py
@@ -370,7 +370,7 @@ class Runner(RunnerBase):
         with Bundle() as bundle:
             for task, label_row in tasks:
                 with ExitStack() as stack:
-                    context = Context(project=project, task=task, label_row=label_row)
+                    context = Context(project=project, task=task, label_row=label_row, agent_stage=stage)
                     dependencies = solve_dependencies(context=context, dependant=runner_agent.dependant, stack=stack)
                     for attempt in range(num_retries + 1):
                         try:

--- a/tests/integration_tests/tasks/test_sequential_runner.py
+++ b/tests/integration_tests/tasks/test_sequential_runner.py
@@ -248,3 +248,19 @@ def test_runner_throws_error_if_wrong_pathway(ephemeral_project_hash: str, pathw
         assert AGENT_TO_COMPLETE_PATHWAY_NAME in str(e)
     else:
         assert AGENT_TO_COMPLETE_PATHWAY_HASH in str(e)
+
+
+def test_queue_runner_resolves_agent_stage(ephemeral_project_hash: str) -> None:
+    runner = Runner(project_hash=ephemeral_project_hash)
+
+    @runner.stage(AGENT_STAGE_NAME)
+    def agent_func(stage: AgentStage) -> str:
+        assert stage
+        assert stage.title == AGENT_STAGE_NAME
+        assert stage.pathways
+        pathway = stage.pathways[0]
+        assert pathway.name == AGENT_TO_COMPLETE_PATHWAY_NAME
+        assert pathway.uuid == AGENT_TO_COMPLETE_PATHWAY_HASH
+        return pathway.name
+
+    runner()


### PR DESCRIPTION
Useful if we want to define some agent that wants to return to pathways programmatically dependant on the stage.
Only really useful for making generic scripts, i.e: Always return to the first pathway.

Would be good if we could delay resolution of the stage until the project is defined.