### PR TITLE
feat: Allow mark items as updated

### DIFF
--- a/docs/task_agents/sequential_runner.md
+++ b/docs/task_agents/sequential_runner.md
@@ -202,6 +202,21 @@ Or in code
 runner(task_batch_size=1)
 ```
 
+Additionally to batch your label row updates to the encord platform, we allow you to return a struct object and we then handle batch saving the results to ensure that you spend as time as possible running your agent and minimising time spent writing results. To use this speed up, please instead write:
+
+```python
+from encord_agents.tasks.models import TaskAgentReturnStruct
+
+@runner.stage("Agent Stage")
+def agent_stage(label_row: LabelRowV2, storage_item: StorageItem) -> TaskAgentReturnStruct:
+    # Modify the label row in any manner
+    label_row.modify()...
+    return TaskAgentReturnStruct(pathway="Modified label", label_row=label_row)
+
+```
+
+We make use of the [bundle method](https://docs.encord.com/sdk-documentation/general-sdk/sdk-bulk-action-best-practices){target="_blank", rel="noopener"}
+
 ## Scaling with the `QueueRunner`
 
 The [`QueueRunner`](./queue_runner.md) is a more advanced runner that will allow you to process multiple tasks in parallel.

--- a/docs/task_agents/sequential_runner.md
+++ b/docs/task_agents/sequential_runner.md
@@ -202,7 +202,7 @@ Or in code
 runner(task_batch_size=1)
 ```
 
-Additionally to batch your label row updates to the encord platform, we allow you to return a struct object and we then handle batch saving the results to ensure that you spend as time as possible running your agent and minimising time spent writing results. To use this speed up, please instead write:
+Additionally to speed up your label row updates to the encord platform, we allow you to return a struct object and we then handle batch saving the results to ensure that you spend as time as possible running your agent and minimising time spent writing results. To use this speed up, please instead write:
 
 ```python
 from encord_agents.tasks.models import TaskAgentReturnStruct
@@ -210,12 +210,12 @@ from encord_agents.tasks.models import TaskAgentReturnStruct
 @runner.stage("Agent Stage")
 def agent_stage(label_row: LabelRowV2, storage_item: StorageItem) -> TaskAgentReturnStruct:
     # Modify the label row in any manner
-    label_row.modify()...
+    # ...
     return TaskAgentReturnStruct(pathway="Modified label", label_row=label_row)
 
 ```
 
-We make use of the [bundle method](https://docs.encord.com/sdk-documentation/general-sdk/sdk-bulk-action-best-practices){target="_blank", rel="noopener"}
+We make use of the [bundle method](https://docs.encord.com/sdk-documentation/general-sdk/sdk-bulk-action-best-practices){target="_blank", rel="noopener"} as in our SDK to batch the label row updates, allowing for >10x speedups.
 
 ## Scaling with the `QueueRunner`
 

--- a/encord_agents/core/dependencies/models.py
+++ b/encord_agents/core/dependencies/models.py
@@ -9,7 +9,21 @@ from encord.workflow.stages.agent import AgentStage, AgentTask
 
 from encord_agents.core.data_model import FrameData
 
-DecoratedCallable = TypeVar("DecoratedCallable", bound=Callable[..., str | UUID | None])
+TaskAgentReturnPathway = str | UUID | None
+
+
+@dataclass
+class TaskAgentReturnStruct:
+    """Return this from your agent and we will handle propagating the updates in batches"""
+
+    pathway: TaskAgentReturnPathway = None
+    storage_item: StorageItem | None = None
+    label_row: LabelRowV2 | None = None
+
+
+TaskAgentReturnType = TaskAgentReturnPathway | TaskAgentReturnStruct
+
+DecoratedCallable = TypeVar("DecoratedCallable", bound=Callable[..., TaskAgentReturnType])
 
 
 class Depends:

--- a/encord_agents/core/dependencies/models.py
+++ b/encord_agents/core/dependencies/models.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, TypeVar
-from uuid import UUID
+from typing import Any, Callable, Optional
 
 from encord.objects.ontology_labels_impl import LabelRowV2
 from encord.project import Project
@@ -8,22 +7,6 @@ from encord.storage import StorageItem
 from encord.workflow.stages.agent import AgentStage, AgentTask
 
 from encord_agents.core.data_model import FrameData
-
-TaskAgentReturnPathway = str | UUID | None
-
-
-@dataclass
-class TaskAgentReturnStruct:
-    """Return this from your agent and we will handle propagating the updates in batches"""
-
-    pathway: TaskAgentReturnPathway = None
-    storage_item: StorageItem | None = None
-    label_row: LabelRowV2 | None = None
-
-
-TaskAgentReturnType = TaskAgentReturnPathway | TaskAgentReturnStruct
-
-DecoratedCallable = TypeVar("DecoratedCallable", bound=Callable[..., TaskAgentReturnType])
 
 
 class Depends:

--- a/encord_agents/tasks/dependencies.py
+++ b/encord_agents/tasks/dependencies.py
@@ -7,11 +7,9 @@ import numpy as np
 from encord.exceptions import AuthenticationError, AuthorisationError, UnknownException
 from encord.objects.ontology_labels_impl import LabelRowV2
 from encord.orm.storage import StorageItemType
-from encord.project import Project
 from encord.storage import StorageItem
 from encord.user_client import EncordUserClient
 from encord.workflow.common import WorkflowTask
-from encord.workflow.stages.agent import AgentTask
 from encord.workflow.workflow import WorkflowStage
 from numpy.typing import NDArray
 from typing_extensions import Annotated

--- a/encord_agents/tasks/models.py
+++ b/encord_agents/tasks/models.py
@@ -1,6 +1,26 @@
+from dataclasses import dataclass
+from typing import Callable, TypeVar
 from uuid import UUID
 
+from encord.objects.ontology_labels_impl import LabelRowV2
+from encord.storage import StorageItem
 from pydantic import BaseModel, Field
+
+TaskAgentReturnPathway = str | UUID | None
+
+
+@dataclass
+class TaskAgentReturnStruct:
+    """Return this from your agent and we will handle propagating the updates in batches"""
+
+    pathway: TaskAgentReturnPathway = None
+    storage_item: StorageItem | None = None
+    label_row: LabelRowV2 | None = None
+
+
+TaskAgentReturnType = TaskAgentReturnPathway | TaskAgentReturnStruct
+
+DecoratedCallable = TypeVar("DecoratedCallable", bound=Callable[..., TaskAgentReturnType])
 
 
 class AgentTaskConfig(BaseModel):

--- a/encord_agents/tasks/models.py
+++ b/encord_agents/tasks/models.py
@@ -3,7 +3,6 @@ from typing import Callable, TypeVar
 from uuid import UUID
 
 from encord.objects.ontology_labels_impl import LabelRowV2
-from encord.storage import StorageItem
 from pydantic import BaseModel, Field
 
 TaskAgentReturnPathway = str | UUID | None
@@ -14,7 +13,6 @@ class TaskAgentReturnStruct:
     """Return this from your agent and we will handle propagating the updates in batches"""
 
     pathway: TaskAgentReturnPathway = None
-    storage_item: StorageItem | None = None
     label_row: LabelRowV2 | None = None
 
 

--- a/encord_agents/tasks/models.py
+++ b/encord_agents/tasks/models.py
@@ -2,8 +2,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-TaskAgentReturn = str | UUID | None
-
 
 class AgentTaskConfig(BaseModel):
     task_uuid: UUID = Field(description="The task uuid", validation_alias="uuid")

--- a/encord_agents/tasks/models.py
+++ b/encord_agents/tasks/models.py
@@ -10,10 +10,18 @@ TaskAgentReturnPathway = str | UUID | None
 
 @dataclass
 class TaskAgentReturnStruct:
-    """Return this from your agent and we will handle propagating the updates in batches"""
+    """
+    Return this from your agent and we will handle propagating the updates in batches
+    """
 
     pathway: TaskAgentReturnPathway = None
+    """
+    The pathway that the task will follow on task completion
+    """
     label_row: LabelRowV2 | None = None
+    """
+    The label to be saved (if present)
+    """
 
 
 TaskAgentReturnType = TaskAgentReturnPathway | TaskAgentReturnStruct

--- a/encord_agents/tasks/runner/queue_runner.py
+++ b/encord_agents/tasks/runner/queue_runner.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Iterable
 from uuid import UUID
 
 from encord.project import Project
-from encord.workflow.stages.agent import AgentStage
+from encord.workflow.stages.agent import AgentStage, AgentTask
 
 from encord_agents.core.data_model import LabelRowInitialiseLabelsArgs, LabelRowMetadataIncludeArgs
 from encord_agents.core.dependencies.utils import solve_dependencies
@@ -13,6 +13,33 @@ from encord_agents.exceptions import PrintableError
 from encord_agents.tasks.models import AgentTaskConfig, TaskAgentReturnStruct, TaskAgentReturnType, TaskCompletionResult
 from encord_agents.tasks.runner.runner_base import RunnerBase
 from encord_agents.utils.generic_utils import try_coerce_UUID
+
+
+def handle_pathway(
+    task: AgentTask,
+    pathway_to_follow: UUID | str | None,
+    pathway_lookup: dict[UUID, str],
+    name_lookup: dict[str, UUID],
+    stage: AgentStage,
+) -> UUID | None:
+    next_stage_uuid: UUID | None = None
+    if pathway_to_follow is None:
+        # TODO: Should we log that task didn't continue?
+        pass
+    elif next_stage_uuid := try_coerce_UUID(pathway_to_follow):
+        if next_stage_uuid not in pathway_lookup.keys():
+            raise PrintableError(
+                f"Runner responded with pathway UUID: {next_stage_uuid}, only accept: {[pathway.uuid for pathway in stage.pathways]}"
+            )
+        task.proceed(pathway_uuid=str(next_stage_uuid))
+    else:
+        if pathway_to_follow not in [pathway.name for pathway in stage.pathways]:
+            raise PrintableError(
+                f"Runner responded with pathway name: {pathway_to_follow}, only accept: {[pathway.name for pathway in stage.pathways]}"
+            )
+        task.proceed(pathway_name=str(pathway_to_follow))
+        next_stage_uuid = name_lookup[str(pathway_to_follow)]
+    return next_stage_uuid
 
 
 class QueueRunner(RunnerBase):
@@ -161,31 +188,22 @@ class QueueRunner(RunnerBase):
                         client=self.client,
                     )
 
-                    next_stage: TaskAgentReturnType = None
                     with ExitStack() as stack:
                         dependencies = solve_dependencies(
                             context=context, dependant=runner_agent.dependant, stack=stack
                         )
-                        next_stage = runner_agent.callable(**dependencies.values)
-                    next_stage_uuid: UUID | None = None
-                    if isinstance(next_stage, TaskAgentReturnStruct):
-                        pass
-                    elif next_stage is None:
-                        # TODO: Should we log that task didn't continue?
-                        pass
-                    elif next_stage_uuid := try_coerce_UUID(next_stage):
-                        if next_stage_uuid not in pathway_lookup.keys():
-                            raise PrintableError(
-                                f"Runner responded with pathway UUID: {next_stage}, only accept: {[pathway.uuid for pathway in stage.pathways]}"
-                            )
-                        task.proceed(pathway_uuid=str(next_stage_uuid))
+                        agent_response: TaskAgentReturnType = runner_agent.callable(**dependencies.values)
+                    pathway_to_follow: UUID | str | None = None
+                    if isinstance(agent_response, TaskAgentReturnStruct):
+                        # Can't batch handle updates for Queue Runner
+                        if agent_response.label_row:
+                            # If the user has returned a struct, we should save in case they haven't actually updated
+                            agent_response.label_row.save()
+                        if agent_response.pathway:
+                            pathway_to_follow = agent_response.pathway
                     else:
-                        if next_stage not in [pathway.name for pathway in stage.pathways]:
-                            raise PrintableError(
-                                f"Runner responded with pathway name: {next_stage}, only accept: {[pathway.name for pathway in stage.pathways]}"
-                            )
-                        task.proceed(pathway_name=str(next_stage))
-                        next_stage_uuid = name_lookup[str(next_stage)]
+                        pathway_to_follow = agent_response
+                    next_stage_uuid = handle_pathway(task, pathway_to_follow, pathway_lookup, name_lookup, stage=stage)
                     return TaskCompletionResult(
                         task_uuid=task.uuid, stage_uuid=stage.uuid, success=True, pathway=next_stage_uuid
                     ).model_dump_json()

--- a/encord_agents/tasks/runner/queue_runner.py
+++ b/encord_agents/tasks/runner/queue_runner.py
@@ -8,10 +8,9 @@ from encord.project import Project
 from encord.workflow.stages.agent import AgentStage
 
 from encord_agents.core.data_model import LabelRowInitialiseLabelsArgs, LabelRowMetadataIncludeArgs
-from encord_agents.core.dependencies.models import TaskAgentReturnStruct, TaskAgentReturnType
 from encord_agents.core.dependencies.utils import solve_dependencies
 from encord_agents.exceptions import PrintableError
-from encord_agents.tasks.models import AgentTaskConfig, TaskCompletionResult
+from encord_agents.tasks.models import AgentTaskConfig, TaskAgentReturnStruct, TaskAgentReturnType, TaskCompletionResult
 from encord_agents.tasks.runner.runner_base import RunnerBase
 from encord_agents.utils.generic_utils import try_coerce_UUID
 

--- a/encord_agents/tasks/runner/queue_runner.py
+++ b/encord_agents/tasks/runner/queue_runner.py
@@ -99,7 +99,7 @@ class QueueRunner(RunnerBase):
         *,
         label_row_metadata_include_args: LabelRowMetadataIncludeArgs | None = None,
         label_row_initialise_labels_args: LabelRowInitialiseLabelsArgs | None = None,
-    ) -> Callable[[Callable[..., str | UUID | None]], Callable[[str], str]]:
+    ) -> Callable[[Callable[..., TaskAgentReturnType]], Callable[[str], str]]:
         """
         Agent wrapper intended for queueing systems and distributed workloads.
 
@@ -132,7 +132,7 @@ class QueueRunner(RunnerBase):
         """
         stage_uuid, printable_name = self._validate_stage(stage)
 
-        def decorator(func: Callable[..., str | UUID | None]) -> Callable[[str], str]:
+        def decorator(func: Callable[..., TaskAgentReturnType]) -> Callable[[str], str]:
             runner_agent = self._add_stage_agent(
                 stage_uuid,
                 func,

--- a/encord_agents/tasks/runner/runner_base.py
+++ b/encord_agents/tasks/runner/runner_base.py
@@ -11,18 +11,21 @@ from encord.workflow.workflow import WorkflowStage
 from typer import Abort
 
 from encord_agents.core.data_model import LabelRowInitialiseLabelsArgs, LabelRowMetadataIncludeArgs
-from encord_agents.core.dependencies.models import Context, Dependant
+from encord_agents.core.dependencies.models import (
+    Context,
+    Dependant,
+    TaskAgentReturnType,
+)
 from encord_agents.core.dependencies.utils import get_dependant
 from encord_agents.core.utils import get_user_client
 from encord_agents.exceptions import PrintableError
-from encord_agents.tasks.models import TaskAgentReturn
 
 
 class RunnerAgent:
     def __init__(
         self,
         identity: str | UUID,
-        callable: Callable[..., TaskAgentReturn],
+        callable: Callable[..., TaskAgentReturnType],
         printable_name: str | None = None,
         label_row_metadata_include_args: LabelRowMetadataIncludeArgs | None = None,
         label_row_initialise_labels_args: LabelRowInitialiseLabelsArgs | None = None,
@@ -213,7 +216,7 @@ class RunnerBase:
     def _add_stage_agent(
         self,
         identity: str | UUID,
-        func: Callable[..., TaskAgentReturn],
+        func: Callable[..., TaskAgentReturnType],
         *,
         stage_insertion: int | None,
         printable_name: str | None,

--- a/encord_agents/tasks/runner/runner_base.py
+++ b/encord_agents/tasks/runner/runner_base.py
@@ -14,11 +14,11 @@ from encord_agents.core.data_model import LabelRowInitialiseLabelsArgs, LabelRow
 from encord_agents.core.dependencies.models import (
     Context,
     Dependant,
-    TaskAgentReturnType,
 )
 from encord_agents.core.dependencies.utils import get_dependant
 from encord_agents.core.utils import get_user_client
 from encord_agents.exceptions import PrintableError
+from encord_agents.tasks.models import TaskAgentReturnType
 
 
 class RunnerAgent:

--- a/encord_agents/tasks/runner/sequential_runner.py
+++ b/encord_agents/tasks/runner/sequential_runner.py
@@ -38,7 +38,7 @@ from encord_agents.tasks.models import DecoratedCallable, TaskAgentReturnStruct,
 from encord_agents.tasks.runner.runner_base import RunnerAgent, RunnerBase
 from encord_agents.utils.generic_utils import try_coerce_UUID
 
-LABEL_ROW_BATCH_SIZE = 100
+MAX_LABEL_ROW_BATCH_SIZE = 100
 
 
 class SequentialRunner(RunnerBase):
@@ -213,7 +213,7 @@ class SequentialRunner(RunnerBase):
         INVARIANT: Tasks should always be for the stage that the runner_agent is associated too
         """
         with Bundle() as task_bundle:
-            with Bundle(bundle_size=LABEL_ROW_BATCH_SIZE) as label_bundle:
+            with Bundle(bundle_size=min(MAX_LABEL_ROW_BATCH_SIZE, len(list(contexts)))) as label_bundle:
                 for context in contexts:
                     assert context.task
                     with ExitStack() as stack:

--- a/encord_agents/tasks/runner/sequential_runner.py
+++ b/encord_agents/tasks/runner/sequential_runner.py
@@ -28,15 +28,13 @@ from typing_extensions import Annotated, Self
 from encord_agents.core.data_model import LabelRowInitialiseLabelsArgs, LabelRowMetadataIncludeArgs
 from encord_agents.core.dependencies.models import (
     Context,
-    DecoratedCallable,
     Dependant,
-    TaskAgentReturnStruct,
-    TaskAgentReturnType,
 )
 from encord_agents.core.dependencies.utils import get_dependant, solve_dependencies
 from encord_agents.core.rich_columns import TaskSpeedColumn
 from encord_agents.core.utils import batch_iterator
 from encord_agents.exceptions import PrintableError
+from encord_agents.tasks.models import DecoratedCallable, TaskAgentReturnStruct, TaskAgentReturnType
 from encord_agents.tasks.runner.runner_base import RunnerAgent, RunnerBase
 from encord_agents.utils.generic_utils import try_coerce_UUID
 
@@ -223,7 +221,7 @@ class SequentialRunner(RunnerBase):
                         )
                         for attempt in range(num_retries + 1):
                             try:
-                                agent_response = runner_agent.callable(**dependencies.values)
+                                agent_response: TaskAgentReturnType = runner_agent.callable(**dependencies.values)
                                 if isinstance(agent_response, TaskAgentReturnStruct):
                                     pathway_to_follow = agent_response.pathway
                                     if agent_response.label_row:

--- a/encord_agents/tasks/runner/sequential_runner.py
+++ b/encord_agents/tasks/runner/sequential_runner.py
@@ -235,15 +235,15 @@ class SequentialRunner(RunnerBase):
                                 elif next_stage_uuid := try_coerce_UUID(pathway_to_follow):
                                     if next_stage_uuid not in [pathway.uuid for pathway in stage.pathways]:
                                         raise PrintableError(
-                                            f"No pathway with UUID: {agent_response} found. Accepted pathway UUIDs are: {[pathway.uuid for pathway in stage.pathways]}"
+                                            f"No pathway with UUID: {next_stage_uuid} found. Accepted pathway UUIDs are: {[pathway.uuid for pathway in stage.pathways]}"
                                         )
                                     task.proceed(pathway_uuid=str(next_stage_uuid), bundle=task_bundle)
                                 else:
                                     if pathway_to_follow not in [str(pathway.name) for pathway in stage.pathways]:
                                         raise PrintableError(
-                                            f"No pathway with name: {agent_response} found. Accepted pathway names are: {[pathway.name for pathway in stage.pathways]}"
+                                            f"No pathway with name: {pathway_to_follow} found. Accepted pathway names are: {[pathway.name for pathway in stage.pathways]}"
                                         )
-                                    task.proceed(pathway_name=str(agent_response), bundle=task_bundle)
+                                    task.proceed(pathway_name=str(pathway_to_follow), bundle=task_bundle)
                                 if pbar_update is not None:
                                     pbar_update(1.0)
                                 break

--- a/tests/integration_tests/tasks/test_queue_runner.py
+++ b/tests/integration_tests/tasks/test_queue_runner.py
@@ -1,17 +1,23 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
+from encord.client import EncordClientProject
+from encord.constants.enums import DataType
+from encord.objects.coordinates import BoundingBoxCoordinates
+from encord.objects.ontology_labels_impl import LabelRowV2
+from encord.objects.ontology_object import Object
 from encord.workflow.stages.agent import AgentStage, AgentTask
 from encord.workflow.stages.final import FinalStage
 
 from encord_agents.exceptions import PrintableError
 from encord_agents.tasks import QueueRunner
-from encord_agents.tasks.models import TaskCompletionResult
+from encord_agents.tasks.models import TaskAgentReturnStruct, TaskCompletionResult
 from tests.fixtures import (
     AGENT_STAGE_NAME,
     AGENT_TO_COMPLETE_PATHWAY_HASH,
     AGENT_TO_COMPLETE_PATHWAY_NAME,
+    BBOX_ONTOLOGY_HASH,
     COMPLETE_STAGE_NAME,
 )
 
@@ -139,3 +145,57 @@ def test_runner_throws_error_if_wrong_pathway(ephemeral_project_hash: str, pathw
             assert AGENT_TO_COMPLETE_PATHWAY_NAME in str(e)
         else:
             assert AGENT_TO_COMPLETE_PATHWAY_HASH in str(e)
+
+
+def test_queue_runner_return_struct_object(ephemeral_image_project_hash: str) -> None:
+    queue_runner = QueueRunner(project_hash=ephemeral_image_project_hash)
+
+    assert queue_runner.project
+    bbox_object = queue_runner.project.ontology_structure.get_child_by_hash(BBOX_ONTOLOGY_HASH, type_=Object)
+    N_items = len(queue_runner.project.list_label_rows_v2())
+
+    @queue_runner.stage(AGENT_STAGE_NAME)
+    def update_label_row(label_row: LabelRowV2) -> TaskAgentReturnStruct:
+        obj_instance = bbox_object.create_instance()
+        obj_instance.set_for_frames(BoundingBoxCoordinates(height=0.5, width=0.5, top_left_x=0, top_left_y=0))
+        label_row.add_object_instance(obj_instance)
+        return TaskAgentReturnStruct(pathway=AGENT_TO_COMPLETE_PATHWAY_HASH, label_row=label_row)
+
+    queue: list[str] = []
+    for stage in queue_runner.get_agent_stages():
+        for task in stage.get_tasks():
+            queue.append(task.model_dump_json())
+
+    # Check tasks are added to Queue appropriately
+    assert len(queue) == N_items
+
+    with patch.object(
+        EncordClientProject, "save_label_rows", side_effect=EncordClientProject.save_label_rows, autospec=True
+    ) as save_label_rows_patch:
+        while queue:
+            task_spec = queue.pop()
+            result_json = update_label_row(task_spec)
+            result = TaskCompletionResult.model_validate_json(result_json)
+            assert result.success
+            assert not result.error
+            assert result.pathway == UUID(AGENT_TO_COMPLETE_PATHWAY_HASH)
+
+        # Verify save_label_rows was called appropriately
+        assert save_label_rows_patch.call_count > 0
+
+    # Verify the objects were added to the label rows
+    lrs = queue_runner.project.list_label_rows_v2()
+    with queue_runner.project.create_bundle() as bundle:
+        for row in lrs:
+            row.initialise_labels(bundle=bundle)
+    for row in lrs:
+        assert row.get_object_instances()
+
+    # Verify tasks were moved from agent stage to final stage
+    agent_stage = queue_runner.project.workflow.get_stage(name=AGENT_STAGE_NAME, type_=AgentStage)
+    agent_stage_tasks = list(agent_stage.get_tasks())
+    assert len(agent_stage_tasks) == 0
+
+    final_stage = queue_runner.project.workflow.get_stage(name=COMPLETE_STAGE_NAME, type_=FinalStage)
+    final_stage_tasks = list(final_stage.get_tasks())
+    assert len(final_stage_tasks) == N_items

--- a/tests/integration_tests/tasks/test_queue_runner.py
+++ b/tests/integration_tests/tasks/test_queue_runner.py
@@ -147,8 +147,8 @@ def test_runner_throws_error_if_wrong_pathway(ephemeral_project_hash: str, pathw
             assert AGENT_TO_COMPLETE_PATHWAY_HASH in str(e)
 
 
-def test_queue_runner_return_struct_object(ephemeral_image_project_hash: str) -> None:
-    queue_runner = QueueRunner(project_hash=ephemeral_image_project_hash)
+def test_queue_runner_return_struct_object(ephemeral_project_hash: str) -> None:
+    queue_runner = QueueRunner(project_hash=ephemeral_project_hash)
 
     assert queue_runner.project
     bbox_object = queue_runner.project.ontology_structure.get_child_by_hash(BBOX_ONTOLOGY_HASH, type_=Object)
@@ -156,6 +156,9 @@ def test_queue_runner_return_struct_object(ephemeral_image_project_hash: str) ->
 
     @queue_runner.stage(AGENT_STAGE_NAME)
     def update_label_row(label_row: LabelRowV2) -> TaskAgentReturnStruct:
+        if label_row.data_type in [DataType.AUDIO, DataType.PLAIN_TEXT]:
+            # TODO: Make instances of objects for these data types
+            return TaskAgentReturnStruct(pathway=AGENT_TO_COMPLETE_PATHWAY_HASH, label_row=label_row)
         obj_instance = bbox_object.create_instance()
         obj_instance.set_for_frames(BoundingBoxCoordinates(height=0.5, width=0.5, top_left_x=0, top_left_y=0))
         label_row.add_object_instance(obj_instance)
@@ -189,6 +192,8 @@ def test_queue_runner_return_struct_object(ephemeral_image_project_hash: str) ->
         for row in lrs:
             row.initialise_labels(bundle=bundle)
     for row in lrs:
+        if row.data_type in [DataType.AUDIO, DataType.PLAIN_TEXT, DataType.PDF]:
+            continue
         assert row.get_object_instances()
 
     # Verify tasks were moved from agent stage to final stage

--- a/tests/integration_tests/tasks/test_sequential_runner.py
+++ b/tests/integration_tests/tasks/test_sequential_runner.py
@@ -2,13 +2,17 @@ from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
+from encord.constants.enums import DataType
+from encord.objects.coordinates import BoundingBoxCoordinates
 from encord.objects.ontology_labels_impl import LabelRowV2
+from encord.objects.ontology_object import Object
 from encord.project import Project
 from encord.storage import StorageItem
 from encord.user_client import EncordUserClient
 from encord.workflow.stages.agent import AgentStage, AgentTask
 from encord.workflow.stages.final import FinalStage
 
+from encord_agents.core.dependencies.models import TaskAgentReturnStruct
 from encord_agents.core.utils import batch_iterator
 from encord_agents.exceptions import PrintableError
 from encord_agents.tasks import SequentialRunner
@@ -288,7 +292,7 @@ def test_runner_storage_item_dependency_resolved_once(ephemeral_image_project_ha
 
 def test_runner_storage_item_order_is_correct(ephemeral_project_hash: str) -> None:
     # With label rows
-    fails = []
+    fails: list[int] = []
     runner = SequentialRunner(project_hash=ephemeral_project_hash)
 
     @runner.stage(AGENT_STAGE_NAME)
@@ -311,3 +315,29 @@ def test_runner_storage_item_order_is_correct(ephemeral_project_hash: str) -> No
 
     runner()
     assert sum(fails) == 0
+
+
+def test_runner_return_struct_object(ephemeral_image_project_hash: str) -> None:
+    runner = SequentialRunner(project_hash=ephemeral_image_project_hash)
+
+    assert runner.project
+    bbox_object = runner.project.ontology_structure.get_child_by_hash("PXFZO2ra", type_=Object)
+
+    @runner.stage(AGENT_STAGE_NAME)
+    def update_label_row(label_row: LabelRowV2) -> TaskAgentReturnStruct:
+        obj_instance = bbox_object.create_instance()
+        obj_instance.set_for_frames(BoundingBoxCoordinates(height=0.5, width=0.5, top_left_x=0, top_left_y=0))
+        label_row.add_object_instance(obj_instance)
+        return TaskAgentReturnStruct(pathway=AGENT_TO_COMPLETE_PATHWAY_HASH, label_row=label_row)
+
+    runner()
+    lrs = runner.project.list_label_rows_v2()
+    for row in lrs:
+        if row.data_type in [DataType.AUDIO, DataType.PLAIN_TEXT, DataType.PDF]:
+            continue
+        row.initialise_labels()
+        assert row.get_object_instances()
+
+    agent_stage = runner.project.workflow.get_stage(name=AGENT_STAGE_NAME, type_=AgentStage)
+    agent_stage_tasks = list(agent_stage.get_tasks())
+    assert len(agent_stage_tasks) == 0

--- a/tests/integration_tests/tasks/test_sequential_runner.py
+++ b/tests/integration_tests/tasks/test_sequential_runner.py
@@ -12,10 +12,10 @@ from encord.user_client import EncordUserClient
 from encord.workflow.stages.agent import AgentStage, AgentTask
 from encord.workflow.stages.final import FinalStage
 
-from encord_agents.core.dependencies.models import TaskAgentReturnStruct
 from encord_agents.core.utils import batch_iterator
 from encord_agents.exceptions import PrintableError
 from encord_agents.tasks import SequentialRunner
+from encord_agents.tasks.models import TaskAgentReturnStruct
 from tests.fixtures import (
     AGENT_STAGE_NAME,
     AGENT_TO_COMPLETE_PATHWAY_HASH,

--- a/tests/integration_tests/tasks/test_sequential_runner.py
+++ b/tests/integration_tests/tasks/test_sequential_runner.py
@@ -16,7 +16,7 @@ from encord_agents.core.utils import batch_iterator
 from encord_agents.exceptions import PrintableError
 from encord_agents.tasks import SequentialRunner
 from encord_agents.tasks.models import TaskAgentReturnStruct
-from encord_agents.tasks.runner.sequential_runner import LABEL_ROW_BATCH_SIZE
+from encord_agents.tasks.runner.sequential_runner import MAX_LABEL_ROW_BATCH_SIZE
 from tests.fixtures import (
     AGENT_STAGE_NAME,
     AGENT_TO_COMPLETE_PATHWAY_HASH,
@@ -337,7 +337,7 @@ def test_runner_return_struct_object(ephemeral_image_project_hash: str) -> None:
         EncordClientProject, "save_label_rows", side_effect=EncordClientProject.save_label_rows, autospec=True
     ) as save_label_rows_patch:
         runner()
-        assert save_label_rows_patch.call_count <= N_items // LABEL_ROW_BATCH_SIZE + 1
+        assert save_label_rows_patch.call_count <= N_items // MAX_LABEL_ROW_BATCH_SIZE + 1
     lrs = runner.project.list_label_rows_v2()
     with runner.project.create_bundle() as bundle:
         for row in lrs:


### PR DESCRIPTION
Not yet fully implemented for the queue runner as passing hydrated objects is somewhat unclear.
But this covers batching of label updates to the Label objects and includes a pretty hefty test.