### PR TITLE
fix: base64 bgr not rgb when using cv2

### DIFF
--- a/encord_agents/core/vision.py
+++ b/encord_agents/core/vision.py
@@ -111,5 +111,17 @@ def crop_to_object(image: NDArray[np.uint8], coordinates: CroppableCoordinates) 
 
 
 def b64_encode_image(img: NDArray[np.uint8], format: Base64Formats = ".jpg") -> str:
+    """
+    Encode an image to a base64 string.
+
+    Args:
+        img: The image to encode. Expects [RGB] channels
+        format: The format of the image.
+
+    Returns:
+        The base64 encoded image.
+    """
+    img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
     _, encoded_image = cv2.imencode(format, img)
     return base64.b64encode(encoded_image).decode("utf-8")  # type: ignore
+

--- a/encord_agents/core/vision.py
+++ b/encord_agents/core/vision.py
@@ -121,7 +121,6 @@ def b64_encode_image(img: NDArray[np.uint8], format: Base64Formats = ".jpg") -> 
     Returns:
         The base64 encoded image.
     """
-    img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+    img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)  # type: ignore
     _, encoded_image = cv2.imencode(format, img)
     return base64.b64encode(encoded_image).decode("utf-8")  # type: ignore
-

--- a/encord_agents/core/vision.py
+++ b/encord_agents/core/vision.py
@@ -121,6 +121,6 @@ def b64_encode_image(img: NDArray[np.uint8], format: Base64Formats = ".jpg") -> 
     Returns:
         The base64 encoded image.
     """
-    img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)  # type: ignore
-    _, encoded_image = cv2.imencode(format, img)
+    coerced_color_img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+    _, encoded_image = cv2.imencode(format, coerced_color_img)
     return base64.b64encode(encoded_image).decode("utf-8")  # type: ignore


### PR DESCRIPTION
We were encoding base64 strings in the wrong way via CV2.

Got inference results like this one:
<img width="1243" alt="image" src="https://github.com/user-attachments/assets/29b626df-4229-431a-b9a4-b2cdb02eaa09" />

This PR should fix that by moving back to BGR land before encoding.

<img width="918" alt="image" src="https://github.com/user-attachments/assets/d5e05fb8-acd1-43c6-9ef7-b0848d00167a" />
