### PR TITLE
testing(pip-install): test that pip install with extras work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ typing-extensions = ">=4.8.0"
 # No-CLI dependencies
 encord = ">=0.1.159"
 numpy = ">=1.26.4"
-opencv-python = {optional = true, extras = ["opencv"], version = ">=4.1"}
-opencv-python-headless = {optional = true, extras = ["headless"], version = ">=4.1"}
+opencv-python = { optional = true, version = ">=4.1" }
+opencv-python-headless = { optional = true, version = ">=4.1" }
 
 [tool.poetry.group.dev.dependencies]
 ipdb = "^0.13.13"
@@ -82,6 +82,9 @@ mkdocs-macros-plugin = "^1.3.7"
 fastapi = "^0.115.0"
 opencv-python = "^4.1"
 
+[tool.poetry.extras]
+opencv = ["opencv-python"]
+opencv-headless = ["opencv-python-headless"]
 
 [tool.poetry.scripts]
 encord-agents = "encord_agents.cli.main:app"
@@ -116,11 +119,11 @@ strict = true
 [tool.pytest.ini_options]
 addopts = "--cov=encord_agents --cov-report=html --junitxml=encord-agents-unit-test-report.xml"
 markers = [
-    "env_mode(AuthMode): mark test to run in a specific environment mode",
+  "env_mode(AuthMode): mark test to run in a specific environment mode",
 ]
 
 [tool.pytest_env]
-ENCORD_SSH_KEY_FILE = {value="tests/integration_tests/private_key_integration_testing", skip_if_set = false}
+ENCORD_SSH_KEY_FILE = { value = "tests/integration_tests/private_key_integration_testing", skip_if_set = false }
 
 [tool.codespell]
 skip = '*.lock,*.ipynb'


### PR DESCRIPTION
Assertions that fresh venv with `encord-agents[opencv]` and `encord-agents[opencv-headless]` works on install. `encord-agents` prints an error.

```
╭─   /tmp/test 
╰─❯ rm -rf venv && \
  python -m venv venv && \
  source venv/bin/activate && \
  python -m pip install -qqq "git+https://github.com/encord-team/encord-agents.git@fhv/testing/pip-install-extras#egg=encord-agents[opencv]" && \
  python agent.py
(360, 640, 3)
⠇ Executing agent `Instruction selection` (total: 1) ? 0:00:01
  Executing batch 0 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0:00:00 ? 100%

╭─   /tmp/test 
╰─❯ rm -rf venv && \
  python -m venv venv && \
  source venv/bin/activate && \
  python -m pip install -qqq "git+https://github.com/encord-team/encord-agents.git@fhv/testing/pip-install-extras#egg=encord-agents[opencv-headless]" && \
  python agent.py
(360, 640, 3)
⠼ Executing agent `Instruction selection` (total: 1) ? 0:00:01
  Executing batch 0 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0:00:00 ? 100%

╭─   /tmp/test
╰─❮ rm -rf venv && \
  python -m venv venv && \
  source venv/bin/activate && \
  python -m pip install -qqq "git+https://github.com/encord-team/encord-agents.git@fhv/testing/pip-install-extras#egg=encord-agents" && \
  python agent.py
Traceback (most recent call last):
  File "/private/tmp/test/venv/lib/python3.12/site-packages/encord_agents/core/vision.py", line 10, in <module>
    import cv2
ModuleNotFoundError: No module named 'cv2'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/private/tmp/test/agent.py", line 3, in <module>
    from encord_agents.tasks.dependencies import dep_single_frame
  File "/private/tmp/test/venv/lib/python3.12/site-packages/encord_agents/__init__.py", line 1, in <module>
    from .core.data_model import FrameData
  File "/private/tmp/test/venv/lib/python3.12/site-packages/encord_agents/core/data_model.py", line 10, in <module>
    from encord_agents.core.vision import DATA_TYPES, b64_encode_image
  File "/private/tmp/test/venv/lib/python3.12/site-packages/encord_agents/core/vision.py", line 12, in <module>
    raise ImportError("Please install `opencv-python` or `opencv-python-headless`.")
ImportError: Please install `opencv-python` or `opencv-python-headless`.

╭─   /tmp/test
╰─❯ cat agent.py
from typing import Annotated
import numpy as np
from encord_agents.tasks.dependencies import dep_single_frame
from encord_agents.tasks import Runner, Depends

r = Runner(project_hash="[redacted]")  # <- 1 video project

@r.stage("Agent 1")
def test(
    fr: Annotated[np.ndarray, Depends(dep_single_frame)],
) -> str | None:
    print(fr.shape)
    return None

if __name__ == '__main__':
    r.run()
```