### PR TITLE
chore: Bump uv version + fix autobump

### DIFF
--- a/.github/actions/setup-root-uv-environment/action.yml
+++ b/.github/actions/setup-root-uv-environment/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Install uv
       uses: astral-sh/setup-uv@v5
       with:
-        version: "0.6.16"
+        version: "0.7.12"
         enable-cache: 'false'
 
     - id: cached-uv

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,9 +23,7 @@ jobs:
         uses: ./.github/actions/setup-root-uv-environment
 
       - name: uv Version Bump
-        # TODO: Remove this once this PR is merged / uv 0.7 is released
-        # https://github.com/astral-sh/uv/pull/12349 
-        run: "uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version ${{ github.ref_name }}"
+        run: uv version ${{ github.ref_name }}
 
       - name: Module Version Bump
         run: 'sed -i "s/__version__ = \".*\"/__version__ = \"${{ github.ref_name }}\"/g" encord_agents/__init__.py'


### PR DESCRIPTION
Currently our publish pipeline requires to resync the lock file after a release. 
An example is here: https://github.com/encord-team/encord-agents/pull/164

With more modern uv, this problem is solved.