### PR TITLE
feat: Allow prefetching dependencies using a Threadpool

### DIFF
--- a/encord_agents/utils/generic_utils.py
+++ b/encord_agents/utils/generic_utils.py
@@ -1,3 +1,5 @@
+import itertools
+from typing import Iterable, TypeVar
 from uuid import UUID
 
 
@@ -9,3 +11,16 @@ def try_coerce_UUID(candidate_uuid: str | UUID) -> UUID | None:
         return UUID(candidate_uuid)
     except ValueError:
         return None
+
+
+T = TypeVar("T")
+
+
+def batch_iterator(iterable: Iterable[T], batch_size: int) -> Iterable[list[T]]:
+    """Batch an iterable into a list of lists"""
+    iterator = iter(iterable)
+    while True:
+        batch = list(itertools.islice(iterator, batch_size))
+        if not batch:
+            break
+        yield batch

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -1,6 +1,5 @@
 from typing import Annotated
 
-from cv2 import meanShift
 from encord.user_client import EncordUserClient
 from fastapi import Depends
 from fastapi.testclient import TestClient


### PR DESCRIPTION
Endless amount of effort could be put into this. Ideally there would be a separate fetch and execute queue. Ideally we could mark our dependencies as async to ensure that when we are fetching them, we can switch between different threads.

This is just one approach