### PR TITLE
feat: [MLT-77] Handle trace id in request and forward onto platform appropriately

### DIFF
--- a/encord_agents/core/constants.py
+++ b/encord_agents/core/constants.py
@@ -4,3 +4,4 @@ ENCORD_DOMAIN_REGEX = (
 
 EDITOR_URL_PARTS_REGEX = r"(?P<domain>https://app\.(us\.)?encord\.com)/label_editor/(?P<projectHash>[\w\d-]{36})/(?P<dataHash>[\w\d-]{36})(/(?P<frame>\d+))?(/(?P<additional_path>[^?]*))?(\?(?P<query>.*))?"
 EDITOR_TEST_REQUEST_HEADER = "X-Encord-Editor-Agent"
+HEADER_CLOUD_TRACE_CONTEXT = "X-Cloud-Trace-Context"

--- a/encord_agents/fastapi/dependencies.py
+++ b/encord_agents/fastapi/dependencies.py
@@ -35,6 +35,7 @@ from encord.storage import StorageItem
 from encord.user_client import EncordUserClient
 from numpy.typing import NDArray
 
+from encord_agents.core.constants import HEADER_CLOUD_TRACE_CONTEXT
 from encord_agents.core.data_model import LabelRowInitialiseLabelsArgs, LabelRowMetadataIncludeArgs
 from encord_agents.core.dependencies.shares import DataLookup
 from encord_agents.core.vision import crop_to_object
@@ -54,8 +55,6 @@ from encord_agents.core.utils import (
     get_user_client,
 )
 from encord_agents.core.video import iter_video
-
-HEADER_CLOUD_TRACE_CONTEXT = "X-Cloud-Trace-Context"
 
 
 def dep_trace_id(request: Request) -> str | None:

--- a/encord_agents/fastapi/dependencies.py
+++ b/encord_agents/fastapi/dependencies.py
@@ -40,7 +40,7 @@ from encord_agents.core.dependencies.shares import DataLookup
 from encord_agents.core.vision import crop_to_object
 
 try:
-    from fastapi import Depends, Form
+    from fastapi import Depends, Form, Request
 except ModuleNotFoundError:
     print(
         'To use the `fastapi` dependencies, you must also install fastapi. `python -m pip install "fastapi[standard]"'
@@ -55,8 +55,18 @@ from encord_agents.core.utils import (
 )
 from encord_agents.core.video import iter_video
 
+HEADER_CLOUD_TRACE_CONTEXT = "X-Cloud-Trace-Context"
 
-def dep_client() -> EncordUserClient:
+
+def dep_trace_id(request: Request) -> str | None:
+    x_cloud_trace_context = request.headers.get(HEADER_CLOUD_TRACE_CONTEXT)
+    if not x_cloud_trace_context:
+        return None
+    trace_id = x_cloud_trace_context.split("/")[0]
+    return trace_id
+
+
+def dep_client(trace_id: Annotated[str | None, Depends(dep_trace_id)]) -> EncordUserClient:
     """
     Dependency to provide an authenticated user client.
 
@@ -74,7 +84,7 @@ def dep_client() -> EncordUserClient:
     ```
 
     """
-    return get_user_client()
+    return get_user_client(trace_id=trace_id)
 
 
 def dep_label_row_with_args(


### PR DESCRIPTION
This introduces a stateful Span ID, receives trace id from the FE request and amends it locally in response to the remote span id.