### PR TITLE
chore: remove upper limit on typer depencency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 dependencies = [
     "pydantic>2.1.0,<3.0.0",
     "pydantic-settings>=2.5.2,<3",
-    "typer>=0.12.5,<0.13",
+    "typer>=0.12.5",
     "requests>=2.32.3,<3",
     "typing-extensions>=4.8.0",
     "encord>=0.1.169",

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">2.1.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.5.2,<3" },
     { name = "requests", specifier = ">=2.32.3,<3" },
-    { name = "typer", specifier = ">=0.12.5,<0.13" },
+    { name = "typer", specifier = ">=0.12.5" },
     { name = "typing-extensions", specifier = ">=4.8.0" },
 ]
 provides-extras = ["vision"]


### PR DESCRIPTION
I, currently, cannot install `encord-agents` next to the latest `fastapi[standard]` as our typer version is too old. Let's fix it.