### PR TITLE
feat: Allow the worker code to process an arbitrary number of tasks at a time

### DIFF
--- a/docs/code_examples/celery/populate_queue.py
+++ b/docs/code_examples/celery/populate_queue.py
@@ -1,4 +1,18 @@
+from itertools import islice
+
 from queue_runner_example import celery_function, runner
+
+
+def batched(iterable, size):
+    it = iter(iterable)
+    batch = list(islice(it, size))
+    while batch:
+        yield batch
+        batch = list(islice(it, size))
+
+
+# Chunk tasks to batch process on individual workers
+CHUNK_SIZE = 10
 
 
 def main():
@@ -8,15 +22,14 @@ def main():
     # Iterate through all agent stages that have implementations
     for stage in runner.get_agent_stages():
         print(f"Processing stage: {stage.title} ({stage.uuid})")
-
         # Get all tasks for this stage
-        for task in stage.get_tasks():
+        for task in batched(stage.get_tasks(), 5 * CHUNK_SIZE):
             # Convert task to JSON spec and send to Celery queue
-            task_spec = task.model_dump_json()
+            task_specs = [task.model_dump_json() for task in task]
 
             # Send task to Celery worker
-            celery_function.delay(task_spec)
-            print(f"Queued task: {task.uuid}")
+            celery_function.chunks(task_specs, CHUNK_SIZE).apply_async()
+            print(f"Queued {len(task_specs)} tasks")
 
         break
 

--- a/docs/code_examples/celery/populate_queue.py
+++ b/docs/code_examples/celery/populate_queue.py
@@ -23,7 +23,7 @@ def main():
     for stage in runner.get_agent_stages():
         print(f"Processing stage: {stage.title} ({stage.uuid})")
         # Get all tasks for this stage
-        for task in batched(stage.get_tasks(), 5 * CHUNK_SIZE):
+        for task in batched(stage.get_tasks(), CHUNK_SIZE):
             # Convert task to JSON spec and send to Celery queue
             task_specs = [task.model_dump_json() for task in task]
 

--- a/docs/task_agents/queue_runner.md
+++ b/docs/task_agents/queue_runner.md
@@ -52,7 +52,7 @@ if __name__ == "__main__":
 
 ## Batched processing on workers
 
-To help minimise overhead on fetching and uploading data from the Encord platform, we also allow you to put multiple tasks on the queue as an individual task. In order to do as such, it's a simple as putting a `list[str]` like object on your chosen queue. For example:
+To reduce the overhead of fetching and uploading data, you can add multiple tasks to the queue at once. Simply pass a `list[str]` object to your chosen queue. For example:
 
 ```python title="batched_queue_agent.py"
 from encord.objects.ontology_labels_impl import LabelRowV2

--- a/docs/task_agents/queue_runner.md
+++ b/docs/task_agents/queue_runner.md
@@ -50,6 +50,45 @@ if __name__ == "__main__":
 !!! tip
     To avoid mixing up the agent implementations, we recommend to use a dedicated queue runner for each agent.
 
+## Batched processing on workers
+
+To help minimise overhead on fetching and uploading data from the Encord platform, we also allow you to put multiple tasks on the queue as an individual task. In order to do as such, it's a simple as putting a `list[str]` like object on your chosen queue. For example:
+
+```python title="batched_queue_agent.py"
+from encord.objects.ontology_labels_impl import LabelRowV2
+from encord_agents.tasks import QueueRunner
+from encord.workflow.stages.agent import AgentTask
+
+runner = QueueRunner(project_hash="<your_project_hash>")
+
+# Agent code stays exactly the same
+@runner.stage("my_stage_name")  # or stage="<stage_uuid>"
+def process_task(task: AgentTask, lr: LabelRowV2) -> str:
+    # No need to change anything about your agent :racing_car:
+    lr.set_priority(0.5)
+    return "next_stage"
+
+BATCH_SIZE = 10
+
+
+# Step 3 & 4: Queue and execute tasks
+if __name__ == "__main__":
+    # Get all tasks that need processing
+    for stage in runner.get_agent_stages():
+        # Your queue implementation
+        task_queue = []
+        
+        # Only need to change code here <--
+        all_tasks = list(stage.get_tasks())
+        batched_tasks = [all_tasks[i:i+BATCH_SIZE] for i in range(0,len(all_tasks), BATCH_SIZE)]
+        for batch in batched_tasks:
+            task_queue.append([task.model_dump_json() for task in batch])
+        
+        while task_queue:
+            task_spec = task_queue.pop()
+            result_json = process_task(task_spec)
+```
+
 ## Integration with Queue Systems
 
 The `QueueRunner` is designed to work with various queue systems. Here are examples with popular frameworks:

--- a/docs/task_agents/sequential_runner.md
+++ b/docs/task_agents/sequential_runner.md
@@ -43,7 +43,7 @@ if __name__ == "__main__":
         project_hash="<your_project_hash">,
         refresh_every=3600,  # seconds
         num_retries = 1,
-        task_batch_size = 1,
+        task_batch_size = 10,
     )
 ```
 

--- a/encord_agents/tasks/models.py
+++ b/encord_agents/tasks/models.py
@@ -46,13 +46,13 @@ class TaskCompletionResult(BaseModel):
     `encord_agents.tasks.QueueRunner` agents.
     """
 
-    task_uuid: UUID = Field(description="UUID of the task in the Encord Queueing system")
+    task_uuid: UUID | list[UUID] = Field(description="UUID of the task in the Encord Queueing system")
     stage_uuid: UUID | None = Field(
         description="UUID of the workflow stage at which the task was executed. If None, the stage could not be identified from the `task_uuid`.",
         default=None,
     )
-    success: bool = Field(description="Agent executed without errors")
-    pathway: UUID | None = Field(
+    success: bool | list[UUID] = Field(description="Agent executed without errors")
+    pathway: UUID | list[UUID] | None = Field(
         description="The UUID of the pathway that the task was passed along to. If None, either the agent succeeded but didn't return a pathway or the agent failed so the task didn't proceed.",
         default=None,
     )

--- a/encord_agents/tasks/runner/queue_runner.py
+++ b/encord_agents/tasks/runner/queue_runner.py
@@ -237,7 +237,7 @@ class QueueRunner(RunnerBase):
                                     pathway_to_follow = agent_response.pathway
                                 if agent_response.label_row_priority:
                                     assert context.label_row is not None
-                                    context.label_row.set_priority(agent_response.label_row_priority)
+                                    context.label_row.set_priority(agent_response.label_row_priority, bundle=bundle)
                             else:
                                 pathway_to_follow = agent_response
                             next_stage_uuid = handle_pathway(

--- a/tests/integration_tests/tasks/test_queue_runner.py
+++ b/tests/integration_tests/tasks/test_queue_runner.py
@@ -86,8 +86,12 @@ def test_queue_runner_worker_batches(ephemeral_project_hash: str, mock_agent: Ma
     queue_runner = QueueRunner(project_hash=ephemeral_project_hash)
 
     @queue_runner.stage(AGENT_STAGE_NAME)
-    def agent_func(agent_task: AgentTask) -> str:
+    def agent_func(
+        label_row: LabelRowV2,
+        agent_task: AgentTask,
+    ) -> str:
         mock_agent(agent_task)
+        assert label_row.is_labelling_initialised
         return AGENT_TO_COMPLETE_PATHWAY_NAME
 
     queue: list[str] = []
@@ -108,17 +112,23 @@ def test_queue_runner_worker_batches(ephemeral_project_hash: str, mock_agent: Ma
     final_stage_tasks = list(final_stage.get_tasks())
     assert len(final_stage_tasks) == 0
 
-    for _batch_start in range(0, N_items, BATCH_SIZE):
-        batch_end = min(_batch_start + BATCH_SIZE, N_items)
-        batch_task_specs = queue[_batch_start:batch_end]
-        task_specs = [AgentTask.model_validate_json(ts) for ts in batch_task_specs]
-        result_json = agent_func(batch_task_specs)
-        result = TaskCompletionResult.model_validate_json(result_json)
-        assert result.success
-        assert not result.error
-        assert result.pathway == [UUID(AGENT_TO_COMPLETE_PATHWAY_HASH) for _ in task_specs]
-        assert result.stage_uuid == agent_stage.uuid
-        assert result.task_uuid == [task_spec.uuid for task_spec in task_specs]
+    with patch.object(
+        EncordClientProject, "list_label_rows", side_effect=EncordClientProject.list_label_rows, autospec=True
+    ) as list_label_rows_patch:
+        for _batch_start in range(0, N_items, BATCH_SIZE):
+            batch_end = min(_batch_start + BATCH_SIZE, N_items)
+            batch_task_specs = queue[_batch_start:batch_end]
+            task_specs = [AgentTask.model_validate_json(ts) for ts in batch_task_specs]
+            result_json = agent_func(batch_task_specs)
+            result = TaskCompletionResult.model_validate_json(result_json)
+            assert result.success
+            assert not result.error
+            assert result.pathway == [UUID(AGENT_TO_COMPLETE_PATHWAY_HASH) for _ in task_specs]
+            assert result.stage_uuid == agent_stage.uuid
+            assert result.task_uuid == [task_spec.uuid for task_spec in task_specs]
+
+        assert list_label_rows_patch.call_count > 0
+        assert list_label_rows_patch.call_count <= (N_items // BATCH_SIZE) + 1
 
     # Have moved the tasks
     agent_stage_tasks = list(agent_stage.get_tasks())


### PR DESCRIPTION
This solves the case where we are effectively just looking to shard the tasks to different workers. People have the flexiibility in their consumer code to configure how things work

Basic Test:
Not fully checking batch behaviour and error handling as with many times, comes room for many errors and have to decide how to resolve certain things