### PR TITLE
fix: Handle both message types

### DIFF
--- a/tests/integration_tests/tasks/test_sequential_runner.py
+++ b/tests/integration_tests/tasks/test_sequential_runner.py
@@ -5,7 +5,7 @@ import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from encord.client import EncordClientProject
-from encord.exceptions import AuthorisationError
+from encord.exceptions import AuthenticationError, AuthorisationError
 from encord.objects.coordinates import BoundingBoxCoordinates
 from encord.objects.ontology_labels_impl import LabelRowV2
 from encord.objects.ontology_object import Object
@@ -405,5 +405,5 @@ def test_runner_can_take_user_client(ephemeral_project_hash: str) -> None:
         encryption_algorithm=serialization.NoEncryption(),
     ).decode("utf-8")
     mock_user_client = EncordUserClient.create_with_ssh_private_key(PRIVATE_KEY_PEM)
-    with pytest.raises(AuthorisationError):
+    with pytest.raises((AuthenticationError, AuthorisationError)):
         SequentialRunner(project_hash=ephemeral_project_hash, user_client=mock_user_client)


### PR DESCRIPTION
We as encord changed something so test needs to be indifferent