### PR TITLE
fix: forward CORS middleware arguments to Starlette by keyword

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,8 +43,6 @@ jobs:
     needs: [setup-venv]
     name: Run tests
     runs-on: ubuntu-latest
-    env:
-      ENCORD_SSH_KEY: ${{ secrets.ENCORD_SSH_KEY }}
     steps:
       - uses: actions/checkout@v3
 
@@ -52,9 +50,9 @@ jobs:
         uses: ./.github/actions/setup-root-uv-environment
 
       - name: Run tests
-        run: |
-          export ENCORD_SSH_KEY='${{ env.ENCORD_SSH_KEY }}'
-          uv run pytest -n auto tests --verbose --junitxml=${{ env.TEST_REPORT }}
+        env:
+          ENCORD_SSH_KEY: ${{ secrets.ENCORD_SSH_KEY }}
+        run: uv run pytest -n auto tests --verbose --junitxml=${{ env.TEST_REPORT }}
 
       - name: Upload report
         uses: actions/upload-artifact@v4
@@ -85,6 +83,8 @@ jobs:
         run: uv run python -c "import fastapi, starlette; print(f'fastapi {fastapi.__version__} / starlette {starlette.__version__}')"
 
       - name: Run fastapi tests
+        env:
+          ENCORD_SSH_KEY: ${{ secrets.ENCORD_SSH_KEY }}
         run: uv run pytest tests/test_cors.py tests/test_fastapi.py tests/test_default_payload.py --verbose
 
   publish-test-reports:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -63,6 +63,30 @@ jobs:
           name: ${{ env.TEST_REPORT }}
           path: ${{ env.TEST_REPORT }}
 
+  # The lockfile pins the oldest supported fastapi (and therefore an old starlette),
+  # so the job above never exercises newer starlette signatures. That is how
+  # https://github.com/encord-team/encord-agents/issues/201 reached users: starlette
+  # 0.51.0 inserted a parameter into `CORSMiddleware.__init__`. This job resolves the
+  # newest fastapi/starlette and re-runs the fastapi-facing tests.
+  tests-latest-fastapi:
+    needs: [setup-venv]
+    name: Run fastapi tests against the newest fastapi/starlette
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup root uv environment
+        uses: ./.github/actions/setup-root-uv-environment
+
+      - name: Resolve the newest fastapi/starlette
+        run: uv lock --upgrade-package fastapi --upgrade-package starlette
+
+      - name: Report resolved versions
+        run: uv run python -c "import fastapi, starlette; print(f'fastapi {fastapi.__version__} / starlette {starlette.__version__}')"
+
+      - name: Run fastapi tests
+        run: uv run pytest tests/test_cors.py tests/test_fastapi.py tests/test_default_payload.py --verbose
+
   publish-test-reports:
     name: Publish test reports
     runs-on: ubuntu-24.04

--- a/encord_agents/fastapi/cors.py
+++ b/encord_agents/fastapi/cors.py
@@ -58,16 +58,20 @@ class EncordCORSMiddleware(CORSMiddleware):  # type: ignore [misc, unused-ignore
         allow_origin_regex: str = ENCORD_DOMAIN_REGEX,
         expose_headers: typing.Sequence[str] = (),
         max_age: int = 3600,
+        **kwargs: typing.Any,
     ) -> None:
+        # Extra keyword arguments are passed straight through to Starlette so that
+        # options only available in newer versions remain usable.
         super().__init__(
             app,
-            allow_origins,
-            allow_methods,
-            allow_headers,
-            allow_credentials,
-            allow_origin_regex,
-            expose_headers,
-            max_age,
+            allow_origins=allow_origins,
+            allow_methods=allow_methods,
+            allow_headers=allow_headers,
+            allow_credentials=allow_credentials,
+            allow_origin_regex=allow_origin_regex,
+            expose_headers=expose_headers,
+            max_age=max_age,
+            **kwargs,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
     "pytest-env>=1.1.5,<2",
     "pytest-xdist>=3.6.1",
     "notebook>=7.3.2,<8",
-    "fastapi>=0.115.0,<0.116",
+    "fastapi>=0.115.0",
     "opencv-python>=4.1",
     "functions-framework>=3.1.0",
 ]
@@ -96,6 +96,7 @@ ignore = ["F401", "E402", "W291"]
 plugins = ['pydantic.mypy']
 exclude = [
     'encord_agents/core/ontology.py',
+    'scratches/',
     'examples/notebooks/',
     'examples/editor_agents/',
     'examples/task_agents/',

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,8 +1,14 @@
+import inspect
 import re
+import typing
 
 import pytest
+from fastapi.testclient import TestClient
+from starlette.middleware.cors import CORSMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
 
-from encord_agents.core.constants import ENCORD_DOMAIN_REGEX
+from encord_agents.core.constants import EDITOR_TEST_REQUEST_HEADER, ENCORD_DOMAIN_REGEX
+from encord_agents.fastapi.cors import EncordCORSMiddleware, get_encord_app
 
 
 @pytest.fixture
@@ -48,3 +54,81 @@ def test_legal_domains_against_CORS_regex(legal_origins: list[str], compiled_reg
 def test_illegal_domains_against_CORS_regex(illegal_origins: list[str], compiled_regex: re.Pattern[str]) -> None:
     for origin in illegal_origins:
         assert not compiled_regex.fullmatch(origin), f"Origin should _not_ have been allowed: `{origin}`"
+
+
+async def _noop_app(scope: Scope, receive: Receive, send: Send) -> None:
+    """Minimal ASGI app, only used to instantiate the middleware."""
+
+
+def test_cors_middleware_binds_arguments_correctly() -> None:
+    """Regression test for https://github.com/encord-team/encord-agents/issues/201.
+
+    Starlette 0.51.0 added an `allow_private_network` parameter in the middle of the
+    `CORSMiddleware.__init__` signature. Forwarding our arguments positionally shifted
+    `expose_headers` and `max_age` onto the wrong parameters, which made the middleware
+    raise `TypeError: can only join an iterable` on construction.
+    """
+    middleware = EncordCORSMiddleware(_noop_app, expose_headers=("X-Custom-Header",), max_age=1234)
+
+    assert middleware.allow_origin_regex is not None
+    assert middleware.allow_origin_regex.pattern == ENCORD_DOMAIN_REGEX
+    assert "POST" in middleware.allow_methods
+    assert middleware.simple_headers["Access-Control-Expose-Headers"] == "X-Custom-Header"
+    assert middleware.preflight_headers["Access-Control-Max-Age"] == "1234"
+
+
+def test_cors_middleware_preflight_response() -> None:
+    app = get_encord_app()
+
+    @app.post("/")
+    def post_root() -> None:
+        return None
+
+    client = TestClient(app)
+    response = client.options(
+        "/",
+        headers={
+            "Origin": "https://app.encord.com",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": EDITOR_TEST_REQUEST_HEADER,
+        },
+    )
+
+    assert response.status_code == 200, response.content
+    assert response.headers["Access-Control-Allow-Origin"] == "https://app.encord.com"
+    assert response.headers["Access-Control-Max-Age"] == "3600"
+    assert EDITOR_TEST_REQUEST_HEADER.lower() in response.headers["Access-Control-Allow-Headers"].lower()
+
+
+def test_cors_middleware_forwards_no_positional_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Guard the mechanism, not just the symptom, of issue #201.
+
+    Positional forwarding only misbehaves against a Starlette version whose
+    `CORSMiddleware.__init__` gained a parameter, so a test asserting on the
+    constructed middleware passes on old Starlette even with the bug present.
+    Asserting that nothing is forwarded positionally fails on every version.
+    """
+    recorded: dict[str, typing.Any] = {}
+
+    def recording_init(self: CORSMiddleware, app: ASGIApp, *args: typing.Any, **kwargs: typing.Any) -> None:
+        recorded["args"] = args
+        recorded["kwargs"] = kwargs
+
+    monkeypatch.setattr(CORSMiddleware, "__init__", recording_init)
+    EncordCORSMiddleware(_noop_app, expose_headers=("X-Custom-Header",), max_age=1234)
+
+    assert recorded["args"] == (), (
+        "Arguments must be forwarded to CORSMiddleware by keyword: positional forwarding silently "
+        "shifts onto the wrong parameters whenever Starlette inserts a new one."
+    )
+    assert recorded["kwargs"]["expose_headers"] == ("X-Custom-Header",)
+    assert recorded["kwargs"]["max_age"] == 1234
+
+
+def test_forwarded_argument_names_exist_in_starlette_signature() -> None:
+    """Keyword forwarding breaks if Starlette ever renames a parameter, so check the names."""
+    starlette_parameters = set(inspect.signature(CORSMiddleware.__init__).parameters)
+    forwarded = set(inspect.signature(EncordCORSMiddleware.__init__).parameters) - {"self", "app", "kwargs"}
+
+    missing = sorted(forwarded - starlette_parameters)
+    assert not missing, f"Arguments no longer accepted by Starlette's CORSMiddleware: {missing}"

--- a/uv.lock
+++ b/uv.lock
@@ -604,7 +604,7 @@ provides-extras = ["vision"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "fastapi", specifier = ">=0.115.0,<0.116" },
+    { name = "fastapi", specifier = ">=0.115.0" },
     { name = "functions-framework", specifier = ">=3.1.0" },
     { name = "ipdb", specifier = ">=0.13.13,<0.14" },
     { name = "ipython", specifier = ">=8.28.0,<9" },


### PR DESCRIPTION
Starlette 0.51.0 added an `allow_private_network` parameter in the middle of `CORSMiddleware.__init__.EncordCORSMiddleware` forwarded its arguments positionally, so `expose_headers` and `max_age` landed on `allow_private_network` and `expose_headers`, and constructing the middleware raised `TypeError: can only join an iterable`. This made the middleware unusable on any app resolving starlette >= 0.51.0.

Forward every argument by keyword and accept `**kwargs` so newer starlette options (e.g. `allow_private_network`) can be passed through.

Fixes #201.