### PR TITLE
feat: support pathway routing from custom agent responses

### DIFF
--- a/encord_agents/aws/wrappers.py
+++ b/encord_agents/aws/wrappers.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from contextlib import ExitStack
 from functools import wraps
@@ -7,7 +8,6 @@ from typing import Any, Callable, Dict, cast
 from encord.exceptions import AuthorisationError
 from encord.objects.ontology_labels_impl import LabelRowV2
 from encord.storage import StorageItem
-from flask import request
 from pydantic import ValidationError
 from pydantic_core import to_jsonable_python
 
@@ -24,12 +24,16 @@ AgentFunction = Callable[..., Any]
 
 def _generate_response(body: dict[str, Any] | None = None, status_code: int | None = None) -> Dict[str, Any]:
     """
-    Generate a Lambda response dictionary with a 200 status code.
+    Generate a Lambda proxy response dictionary.
+
+    The body is serialised here: API Gateway requires the `body` of a proxy response to
+    be a string and discards the response otherwise, so handing it a dict means the
+    agent's response never reaches Encord.
     """
     has_body = bool(body)
     return {
         "statusCode": status_code or (200 if has_body else 204),
-        "body": to_jsonable_python(body) if has_body else "",  # Lambda expects a string body, even if empty
+        "body": json.dumps(to_jsonable_python(body)) if has_body else "",
         # "headers": CORS headers are handled by AWS Lambda from the configurations.
     }
 
@@ -60,7 +64,10 @@ def editor_agent(
                 body = event.get("body")
                 frame_data: FrameData | None = None
                 if not body:
-                    return {"statusCode": 400, "body": {"errors": ["No request body"], "message": "No request body"}}
+                    return _generate_response(
+                        body={"errors": ["No request body"], "message": "No request body"},
+                        status_code=HTTPStatus.BAD_REQUEST,
+                    )
                 if isinstance(body, str):
                     logging.info("Parsing body as string json")
                     frame_data = FrameData.model_validate_json(body)
@@ -70,13 +77,13 @@ def editor_agent(
                 logging.info(f"Request: {frame_data}")
             except ValidationError as err:
                 logging.error(f"Error parsing request: {err}")
-                return {
-                    "statusCode": 400,
-                    "body": {
+                return _generate_response(
+                    body={
                         "errors": err.errors(),
                         "message": ", ".join([e["msg"] for e in err.errors()]),
                     },
-                }
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
             frame_data = cast(FrameData, frame_data)
 
             client = get_user_client(trace_id=trace_id)
@@ -117,7 +124,7 @@ def editor_agent(
                 try:
                     result = func(**dependencies.values)
                     if isinstance(result, EditorAgentResponse):
-                        return _generate_response(result.model_dump())
+                        return _generate_response(result.model_dump(mode="json", exclude_none=True))
                     return _generate_response()
                 except EncordEditorAgentException as exc:
                     return _generate_response(

--- a/encord_agents/aws/wrappers.py
+++ b/encord_agents/aws/wrappers.py
@@ -26,7 +26,7 @@ def _generate_response(body: dict[str, Any] | None = None, status_code: int | No
     """
     Generate a Lambda proxy response dictionary.
 
-    The body is serialised here: API Gateway requires the `body` of a proxy response to
+    The body is serialized here: API Gateway requires the `body` of a proxy response to
     be a string and discards the response otherwise, so handing it a dict means the
     agent's response never reaches Encord.
     """
@@ -124,7 +124,7 @@ def editor_agent(
                 try:
                     result = func(**dependencies.values)
                     if isinstance(result, EditorAgentResponse):
-                        return _generate_response(result.model_dump(mode="json", exclude_none=True))
+                        return _generate_response(result.model_dump(mode="json"))
                     return _generate_response()
                 except EncordEditorAgentException as exc:
                     return _generate_response(

--- a/encord_agents/core/constants.py
+++ b/encord_agents/core/constants.py
@@ -5,3 +5,6 @@ ENCORD_DOMAIN_REGEX = (
 EDITOR_URL_PARTS_REGEX = r"(?P<domain>https://app\.(us\.)?encord\.com)/label_editor/(?P<projectHash>[\w\d-]{36})/(?P<dataHash>[\w\d-]{36})(/(?P<frame>\d+))?(/(?P<additional_path>[^?]*))?(\?(?P<query>.*))?"
 EDITOR_TEST_REQUEST_HEADER = "X-Encord-Editor-Agent"
 HEADER_CLOUD_TRACE_CONTEXT = "X-Cloud-Trace-Context"
+# Cap on `decision`, the pathway name a custom agent returns to route its task.
+# Encord silently drops a longer one and takes the default pathway; fail loudly here.
+MAX_DECISION_LENGTH = 256

--- a/encord_agents/core/data_model.py
+++ b/encord_agents/core/data_model.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
-from typing import Literal, overload
+from typing import Any, Literal, overload
 from uuid import UUID
 
 import numpy as np
 from encord.objects.ontology_object_instance import ObjectInstance
 from numpy.typing import NDArray
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_serializer, model_validator
+from pydantic.functional_serializers import SerializerFunctionWrapHandler
 from typing_extensions import Self
 
 from encord_agents.core.constants import MAX_DECISION_LENGTH
@@ -201,3 +202,11 @@ class EditorAgentResponse(BaseModel):
         if value is None:
             return None
         return value.strip() or None
+
+    @model_serializer(mode="wrap")
+    def _omit_unset(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+        # Encord reads absent and null identically, so an unset field is noise on the
+        # wire. Doing this on the model rather than at each call site keeps the three
+        # deployment paths identical: FastAPI serializes this model itself, so a
+        # wrapper-level `exclude_none` would never reach that path.
+        return {key: value for key, value in handler(self).items() if value is not None}

--- a/encord_agents/core/data_model.py
+++ b/encord_agents/core/data_model.py
@@ -5,8 +5,14 @@ from uuid import UUID
 import numpy as np
 from encord.objects.ontology_object_instance import ObjectInstance
 from numpy.typing import NDArray
-from pydantic import BaseModel, Field, field_validator, model_serializer, model_validator
-from pydantic.functional_serializers import SerializerFunctionWrapHandler
+from pydantic import (
+    BaseModel,
+    Field,
+    SerializerFunctionWrapHandler,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 from typing_extensions import Self
 
 from encord_agents.core.constants import MAX_DECISION_LENGTH

--- a/encord_agents/core/data_model.py
+++ b/encord_agents/core/data_model.py
@@ -5,8 +5,10 @@ from uuid import UUID
 import numpy as np
 from encord.objects.ontology_object_instance import ObjectInstance
 from numpy.typing import NDArray
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from typing_extensions import Self
+
+from encord_agents.core.constants import MAX_DECISION_LENGTH
 
 Base64Formats = Literal[".jpeg", ".jpg", ".png"]
 
@@ -173,4 +175,29 @@ class EditorAgentResponse(BaseModel):
     message: str | None = None
     """
     A message to be displayed to the user.
+
+    Purely informational: it never affects routing or labels. Encord truncates
+    messages longer than 256 characters.
     """
+    decision: str | None = Field(default=None, max_length=MAX_DECISION_LENGTH)
+    """
+    The name of the workflow pathway that the task should follow.
+
+    Only honoured for workflow-triggered agents. An agent invoked from the Label
+    Editor has no task to route, so Encord ignores the field there.
+
+    The value must match one of the agent stage's configured pathway names. An
+    unmatched name fails the execution rather than falling back, and the name is
+    matched verbatim -- a pathway UUID is not accepted. When omitted, the stage's
+    default pathway is used, or its only pathway if it has exactly one.
+    """
+
+    @field_validator("message", "decision", mode="before")
+    @classmethod
+    def _blank_is_unset(cls, value: str | None) -> str | None:
+        # Encord strips both fields and treats blank as absent. Mirroring that keeps a
+        # blank `decision` on the default-pathway branch instead of making it look like
+        # a routing instruction that silently does nothing.
+        if value is None:
+            return None
+        return value.strip() or None

--- a/encord_agents/gcp/wrappers.py
+++ b/encord_agents/gcp/wrappers.py
@@ -139,7 +139,7 @@ def editor_agent(
                 try:
                     result = func(**dependencies.values)
                     if isinstance(result, EditorAgentResponse):
-                        response = _generate_response(result.model_dump_json(exclude_none=True), HTTPStatus.OK)
+                        response = _generate_response(result.model_dump_json(), HTTPStatus.OK)
                         return response
                 except EncordEditorAgentException as exc:
                     response = _generate_response(to_jsonable_python(exc.json_response_body), HTTPStatus.BAD_REQUEST)

--- a/encord_agents/gcp/wrappers.py
+++ b/encord_agents/gcp/wrappers.py
@@ -73,7 +73,7 @@ def editor_agent(
                 response.headers["Vary"] = "Origin"
 
                 if not cors_regex.fullmatch(request.origin):
-                    response.status_code = 403
+                    response.status_code = HTTPStatus.FORBIDDEN
                     return response
 
                 headers = {
@@ -83,7 +83,7 @@ def editor_agent(
                     "Access-Control-Max-Age": "3600",
                 }
                 response.headers.update(headers)
-                response.status_code = 204
+                response.status_code = HTTPStatus.NO_CONTENT
                 return response
 
             if request.headers.get(EDITOR_TEST_REQUEST_HEADER):
@@ -139,7 +139,7 @@ def editor_agent(
                 try:
                     result = func(**dependencies.values)
                     if isinstance(result, EditorAgentResponse):
-                        response = _generate_response(result.model_dump_json(), HTTPStatus.OK)
+                        response = _generate_response(result.model_dump_json(exclude_none=True), HTTPStatus.OK)
                         return response
                 except EncordEditorAgentException as exc:
                     response = _generate_response(to_jsonable_python(exc.json_response_body), HTTPStatus.BAD_REQUEST)

--- a/examples/editor_agents/fastapi/fastapi_pathway_routing.py
+++ b/examples/editor_agents/fastapi/fastapi_pathway_routing.py
@@ -1,0 +1,60 @@
+"""A custom agent that routes its task through the workflow by returning a `decision`.
+
+Register this endpoint on an agent stage whose pathways are named `accept` and `reject`.
+When the workflow triggers the agent, Encord matches the returned `decision` against
+those pathway names and moves the task along that pathway.
+
+Note that `decision` is only honoured for workflow-triggered runs. The same endpoint
+invoked from the Label Editor has no task to route, so Encord ignores `decision` there
+and only `message` is surfaced -- which means one endpoint can serve both, as below.
+"""
+
+from encord.objects import Shape
+from encord.objects.coordinates import BoundingBoxCoordinates
+from encord.objects.ontology_labels_impl import LabelRowV2
+from encord.objects.ontology_object_instance import ObjectInstance
+from fastapi import Depends
+from typing_extensions import Annotated
+
+from encord_agents.core.data_model import EditorAgentResponse
+from encord_agents.fastapi.cors import get_encord_app
+from encord_agents.fastapi.dependencies import FrameData, dep_label_row
+
+app = get_encord_app()
+
+# Reject a frame whose boxes are implausibly small; a real agent would do something
+# more interesting here. Coordinates are normalised, so this is a fraction of the image.
+MIN_BOX_AREA = 0.001
+
+
+def _relative_box_area(box: ObjectInstance, frame: int) -> float:
+    coords = box.get_annotation(frame).coordinates
+    # Guaranteed by the shape filter below, and asserted rather than duck-typed so a
+    # non-box slipping through fails here instead of quietly scoring as full-size.
+    assert isinstance(coords, BoundingBoxCoordinates)
+    return coords.width * coords.height
+
+
+@app.post("/qa_routing")
+def qa_routing(
+    frame_data: FrameData,
+    lr: Annotated[LabelRowV2, Depends(dep_label_row)],
+) -> EditorAgentResponse:
+    # Narrow to the shape this agent understands before touching any coordinates.
+    # Ontologies mix shapes, and only bounding boxes have a width and a height.
+    boxes = [
+        instance
+        for instance in lr.get_object_instances(filter_frames=frame_data.frame)
+        if instance.ontology_item.shape == Shape.BOUNDING_BOX
+    ]
+    too_small = [box for box in boxes if _relative_box_area(box, frame_data.frame) < MIN_BOX_AREA]
+
+    if too_small:
+        # The pathway name must match the stage's configuration exactly; an unmatched
+        # name fails the execution rather than falling back to the default pathway.
+        return EditorAgentResponse(
+            decision="reject",
+            message=f"{len(too_small)} of {len(boxes)} box(es) are too small.",
+        )
+
+    return EditorAgentResponse(decision="accept", message=f"Checked {len(boxes)} box(es).")

--- a/tests/test_editor_agent_response.py
+++ b/tests/test_editor_agent_response.py
@@ -1,0 +1,97 @@
+"""Serialisation contract for `EditorAgentResponse` across the serverless wrappers.
+
+Encord reads `decision` and `message` off the JSON body of a 2xx agent response, so
+these tests assert the wire shape each wrapper produces, not just that it returned.
+"""
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask, Request
+from pydantic import ValidationError
+from werkzeug.test import EnvironBuilder
+
+from encord_agents.aws.wrappers import editor_agent as aws_editor_agent
+from encord_agents.core.data_model import EditorAgentResponse, FrameData
+from encord_agents.gcp.wrappers import editor_agent as gcp_editor_agent
+
+PAYLOAD = {
+    "projectHash": "00000000-0000-0000-0000-000000000000",
+    "dataHash": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "frame": 0,
+}
+
+
+def test_decision_strips_and_treats_blank_as_unset() -> None:
+    assert EditorAgentResponse(decision="  accept  ").decision == "accept"
+    assert EditorAgentResponse(decision="   ").decision is None
+    assert EditorAgentResponse(decision="").decision is None
+    assert EditorAgentResponse(message="\t\n").message is None
+
+
+def test_decision_longer_than_the_platform_cap_is_rejected() -> None:
+    # Encord silently ignores an over-long decision and routes via the default pathway,
+    # so failing loudly here is the difference between an error and a wrong pathway.
+    with pytest.raises(ValidationError):
+        EditorAgentResponse(decision="x" * 257)
+
+    assert EditorAgentResponse(decision="x" * 256).decision is not None
+
+
+def _gcp_response_body(response: EditorAgentResponse) -> dict[str, Any]:
+    @gcp_editor_agent()
+    def agent(frame_data: FrameData) -> EditorAgentResponse:
+        return response
+
+    request = Request(EnvironBuilder(method="POST", json=PAYLOAD).get_environ())
+    with patch("encord_agents.gcp.wrappers.get_user_client", return_value=MagicMock()):
+        # `make_response` needs an application context; the request above is what the
+        # wrapper actually reads.
+        with Flask(__name__).test_request_context():
+            flask_response = agent(request)
+    assert flask_response.status_code == 200
+    body: dict[str, Any] = json.loads(flask_response.get_data(as_text=True))
+    return body
+
+
+def _aws_response(response: EditorAgentResponse) -> dict[str, Any]:
+    @aws_editor_agent()
+    def agent(frame_data: FrameData) -> EditorAgentResponse:
+        return response
+
+    with patch("encord_agents.aws.wrappers.get_user_client", return_value=MagicMock()):
+        return agent({"headers": {}, "body": json.dumps(PAYLOAD)}, None)
+
+
+def test_gcp_serialises_decision_and_omits_unset_fields() -> None:
+    body = _gcp_response_body(EditorAgentResponse(decision="accept"))
+    assert body == {"decision": "accept"}
+
+    body = _gcp_response_body(EditorAgentResponse(decision="reject", message="Two boxes out of bounds"))
+    assert body == {"decision": "reject", "message": "Two boxes out of bounds"}
+
+
+def test_aws_body_is_a_json_string() -> None:
+    # API Gateway discards a proxy response whose body is not a string, which would
+    # drop the decision on the floor without any error surfacing.
+    aws_response = _aws_response(EditorAgentResponse(decision="accept"))
+    assert isinstance(aws_response["body"], str)
+    assert json.loads(aws_response["body"]) == {"decision": "accept"}
+
+
+def test_aws_error_bodies_are_json_strings() -> None:
+    @aws_editor_agent()
+    def agent(frame_data: FrameData) -> None:
+        return None
+
+    missing_body = agent({"headers": {}}, None)
+    assert missing_body["statusCode"] == 400
+    assert isinstance(missing_body["body"], str)
+    assert json.loads(missing_body["body"])["message"] == "No request body"
+
+    malformed = agent({"headers": {}, "body": json.dumps({"frame": -1})}, None)
+    assert malformed["statusCode"] == 400
+    assert isinstance(malformed["body"], str)
+    assert json.loads(malformed["body"])["errors"]

--- a/tests/test_editor_agent_response.py
+++ b/tests/test_editor_agent_response.py
@@ -65,7 +65,7 @@ def _aws_response(response: EditorAgentResponse) -> dict[str, Any]:
         return agent({"headers": {}, "body": json.dumps(PAYLOAD)}, None)
 
 
-def test_gcp_serialises_decision_and_omits_unset_fields() -> None:
+def test_gcp_serializes_decision_and_omits_unset_fields() -> None:
     body = _gcp_response_body(EditorAgentResponse(decision="accept"))
     assert body == {"decision": "accept"}
 


### PR DESCRIPTION
Encord has accepted a `decision` field on a custom agent's response body since June, matching it against the agent stage's pathway names to route the task. `EditorAgentResponse` only carried `message`, so an agent written with this package had no way to express one.

### `decision`

The field mirrors the platform's handling rather than inventing its own:

| Returned | Encord does | Handled here |
| --- | --- | --- |
| `"accept"` | routes down the `accept` pathway | — |
| blank or whitespace | treats as unset, default pathway | stripped to `None`, so it cannot read as an instruction that silently does nothing |
| 257+ chars | silently dropped, default pathway | rejected at construction; the alternative is a wrong pathway with no error anywhere |
| a pathway UUID | not accepted, names only | documented on the field |
| unmatched name | fails the execution, no fallback | documented on the field |

Only honoured for workflow-triggered runs — the Label Editor has no task to route and ignores the field — so one endpoint can serve both, as the new example shows.

### AWS

The wrapper imported `flask` without using it. Flask is not a dependency of this package; it only reaches a development environment transitively through `functions-framework`, which is GCP's runtime. A Lambda image has no flask, so `encord_agents.aws` raises `Runtime.ImportModuleError` before the handler runs, meaning no AWS editor agent built with this package could start. Reproduced with `sam local`. Note that `pyproject.toml` has `F401` both selected and ignored, so unused imports are never reported — which is how a crash-on-import went unnoticed.

`_generate_response` also put a dict in the proxy response `body`, where API Gateway documents a string; `json.dumps` conforms. That one is a spec fix rather than an observed failure: SAM's emulator accepts a dict body, and it has not been checked against a live API Gateway deployment.

### Verification and limits

`decision` is verified end to end on GCP, against a deployed function registered as a custom agent endpoint on an agent stage. On AWS, coverage is the `sam local` import reproduction plus unit tests pinning the response shape; a live Lambda deployment is still outstanding.

Verifying the signature Encord sends with each request is not part of this change and lands separately. Deployable GCP and AWS examples are also not included — the routing example is FastAPI only.
